### PR TITLE
Disable google signin based on env

### DIFF
--- a/server/dashboard_react/src/App.tsx
+++ b/server/dashboard_react/src/App.tsx
@@ -25,6 +25,7 @@ import { Signup } from "./components/Signup";
 import Release from "./components/Release";
 import axios from "./api/axios";
 import Toast from "./components/Toast";
+import { Configuration } from "./types";
 
 // Types
 interface User {
@@ -56,10 +57,25 @@ const App: React.FC = () => {
   const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false);
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [configurations, setConfigurations] = useState<Configuration>({
+    enableGoogleSignIn: false,
+  });
   console.log("rendering app");
 
   // Consolidate authentication check into a single useEffect
   useEffect(() => {
+    const getGlobalConfigurations = async () => {
+      try {
+        const { data } = await axios.get("/dashboard/configuration/");
+        console.log("Global Configurations:", data);
+        setConfigurations({
+          enableGoogleSignIn: data.google_signin_enabled || false,
+        });
+      } catch (error) {
+        console.error("Failed to fetch global configurations:", error);
+      }
+    }
+    getGlobalConfigurations();
     const checkAuthStatus = async () => {
       const token =
         localStorage.getItem("userToken") ||
@@ -155,11 +171,12 @@ const App: React.FC = () => {
               <Login
                 setIsAuthenticated={setIsAuthenticated}
                 setUser={setUser}
+                configuration={configurations}
               />
             )
           }
         />
-        <Route path="/dashboard/signup" element={<Signup></Signup>} />
+        <Route path="/dashboard/signup" element={<Signup configuration={configurations}></Signup>} />
         <Route
           path="/dashboard"
           element={

--- a/server/dashboard_react/src/components/Login.tsx
+++ b/server/dashboard_react/src/components/Login.tsx
@@ -1,5 +1,5 @@
 import React from "react"; // Removed unused useState, useEffect
-import { User } from "../types";
+import { Configuration, User } from "../types";
 import { AuthLayout } from './layouts/AuthLayout';
 import { LoginForm } from './auth/LoginForm';
 
@@ -7,12 +7,13 @@ import { LoginForm } from './auth/LoginForm';
 interface LoginPageProps {
   setIsAuthenticated: (isAuthenticated: boolean) => void;
   setUser: (user: User) => void;
+  configuration: Configuration;
 }
 
-export const Login: React.FC<LoginPageProps> = ({ setIsAuthenticated, setUser }) => {
+export const Login: React.FC<LoginPageProps> = ({ setIsAuthenticated, setUser, configuration }) => {
   return (
     <AuthLayout>
-      <LoginForm setIsAuthenticated={setIsAuthenticated} setUser={setUser} />
+      <LoginForm setIsAuthenticated={setIsAuthenticated} setUser={setUser} configuration={configuration} />
     </AuthLayout>
   );
 };

--- a/server/dashboard_react/src/components/Signup.tsx
+++ b/server/dashboard_react/src/components/Signup.tsx
@@ -2,16 +2,21 @@ import React from "react"; // Removed unused useState, useEffect
 // Removed User type as it's not directly used by Signup page wrapper
 import { AuthLayout } from './layouts/AuthLayout';
 import { SignupForm } from './auth/SignupForm';
+import { Configuration } from "../types";
 
 // Signup page typically doesn't need to set auth state directly,
 // that's handled by login or token validation after signup.
 // If props were needed, they would be defined here.
 // interface SignupPageProps {}
 
-export const Signup: React.FC = () => { // Removed props if not needed by SignupForm directly
+interface SignupPageProps {
+  configuration: Configuration;
+}
+
+export const Signup: React.FC<SignupPageProps> = ({ configuration }) => { // Removed props if not needed by SignupForm directly
   return (
     <AuthLayout>
-      <SignupForm />
+      <SignupForm configuration={configuration} />
     </AuthLayout>
   );
 };

--- a/server/dashboard_react/src/components/auth/LoginForm.tsx
+++ b/server/dashboard_react/src/components/auth/LoginForm.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { Loader, AlertCircle, User as UserIcon, Lock } from "lucide-react";
 import { useNavigate } from "react-router-dom";
-import { User } from "../../types"; // Adjusted path
+import { Configuration, User } from "../../types"; // Adjusted path
 import axios from "../../api/axios"; // Adjusted path
 import { IconEyeClosed } from "../icons/IconEyeClosed"; // Adjusted path
 import { IconEyeOpen } from "../icons/IconEyeOpen"; // Adjusted path
@@ -10,6 +10,7 @@ import logoImage from "../../assets/airborne-cube-logo.png"; // Adjusted path
 interface LoginFormProps {
   setIsAuthenticated: (isAuthenticated: boolean) => void;
   setUser: (user: User) => void;
+  configuration: Configuration
 }
 
 interface LoginFormData {
@@ -22,7 +23,7 @@ interface ErrorState {
   message: string;
 }
 
-export const LoginForm: React.FC<LoginFormProps> = ({ setIsAuthenticated, setUser }) => {
+export const LoginForm: React.FC<LoginFormProps> = ({ setIsAuthenticated, setUser, configuration }) => {
   const [formData, setFormData] = useState<LoginFormData>({
     name: "",
     password: "",
@@ -327,44 +328,46 @@ export const LoginForm: React.FC<LoginFormProps> = ({ setIsAuthenticated, setUse
         </div>
       </form>
 
-      <div className="mt-6 text-xs">
-        <div className="relative">
-          <div className="absolute inset-0 flex items-center">
-            <div className="w-full border-t border-slate-700" />
+      {configuration.enableGoogleSignIn && (
+        <div className="mt-6 text-xs">
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center">
+              <div className="w-full border-t border-slate-700" />
+            </div>
+            <div className="relative flex justify-center">
+              <span className="px-2 bg-neutral-900 text-slate-500"> 
+                Or continue with
+              </span>
+            </div>
           </div>
-          <div className="relative flex justify-center">
-            <span className="px-2 bg-neutral-900 text-slate-500"> 
-              Or continue with
-            </span>
-          </div>
-        </div>
 
-        <div className="mt-4">
-          <button
-            type="button"
-            onClick={handleGoogleLogin}
-            disabled={isLoading || isGoogleLoading}
-            className="w-full inline-flex justify-center items-center py-2.5 px-4 border border-slate-700 rounded-md shadow-sm bg-slate-800 text-sm font-medium text-slate-300 hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-neutral-900 focus:ring-blue-500 disabled:opacity-70 disabled:cursor-not-allowed"
-          >
-            {isGoogleLoading ? (
-              <>
-                <Loader size={18} className="animate-spin mr-2" />
-                Connecting to Google...
-              </>
-            ) : (
-              <>
-                <svg className="w-4 h-4 mr-2" viewBox="0 0 24 24">
-                  <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
-                  <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
-                  <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
-                  <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
-                </svg>
-                Sign in with Google
-              </>
-            )}
-          </button>
+          <div className="mt-4">
+            <button
+              type="button"
+              onClick={handleGoogleLogin}
+              disabled={isLoading || isGoogleLoading}
+              className="w-full inline-flex justify-center items-center py-2.5 px-4 border border-slate-700 rounded-md shadow-sm bg-slate-800 text-sm font-medium text-slate-300 hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-neutral-900 focus:ring-blue-500 disabled:opacity-70 disabled:cursor-not-allowed"
+            >
+              {isGoogleLoading ? (
+                <>
+                  <Loader size={18} className="animate-spin mr-2" />
+                  Connecting to Google...
+                </>
+              ) : (
+                <>
+                  <svg className="w-4 h-4 mr-2" viewBox="0 0 24 24">
+                    <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+                    <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+                    <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+                    <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+                  </svg>
+                  Sign in with Google
+                </>
+              )}
+            </button>
+          </div>
         </div>
-      </div>
+      )}
 
       <div className="mt-6 text-center text-xs text-slate-400">
         Don't have an account?{' '}

--- a/server/dashboard_react/src/components/auth/SignupForm.tsx
+++ b/server/dashboard_react/src/components/auth/SignupForm.tsx
@@ -5,6 +5,7 @@ import axios from "../../api/axios"; // Adjusted path
 import { IconEyeClosed } from "../icons/IconEyeClosed"; // Adjusted path
 import { IconEyeOpen } from "../icons/IconEyeOpen"; // Adjusted path
 import logoImage from '../../assets/airborne-cube-logo.png';
+import { Configuration } from "../../types";
 
 interface SignupFormData {
   name: string;
@@ -17,7 +18,11 @@ interface ErrorState {
   message: string;
 }
 
-export const SignupForm: React.FC = () => {
+interface SignupFormProps {
+  configuration: Configuration;
+}
+
+export const SignupForm: React.FC<SignupFormProps> = ({ configuration }) => {
   const [formData, setFormData] = useState<SignupFormData>({
     name: "",
     password: "",
@@ -244,38 +249,40 @@ export const SignupForm: React.FC = () => {
         </div>
       </form>
 
-      <div className="mt-6 text-xs">
-        <div className="relative">
-          <div className="absolute inset-0 flex items-center"><div className="w-full border-t border-slate-700" /></div>
-          <div className="relative flex justify-center">
-            <span className="px-2 bg-neutral-900 text-slate-500">Or continue with</span>
+      {configuration.enableGoogleSignIn && (
+        <div className="mt-6 text-xs">
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center"><div className="w-full border-t border-slate-700" /></div>
+            <div className="relative flex justify-center">
+              <span className="px-2 bg-neutral-900 text-slate-500">Or continue with</span>
+            </div>
+          </div>
+          <div className="mt-4">
+            <button 
+              type="button"
+              onClick={handleGoogleSignup}
+              disabled={isLoading || success || isGoogleLoading}
+              className="w-full inline-flex justify-center items-center py-2.5 px-4 border border-slate-700 rounded-md shadow-sm bg-slate-800 text-sm font-medium text-slate-300 hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-neutral-900 focus:ring-blue-500 disabled:opacity-70 disabled:cursor-not-allowed">
+              {isGoogleLoading ? (
+                <>
+                  <Loader size={18} className="animate-spin mr-2" />
+                  Connecting to Google...
+                </>
+              ) : (
+                <>
+                  <svg className="w-4 h-4 mr-2" viewBox="0 0 24 24">
+                    <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+                    <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+                    <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+                    <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+                  </svg>
+                  Sign up with Google
+                </>
+              )}
+            </button>
           </div>
         </div>
-        <div className="mt-4">
-          <button 
-            type="button"
-            onClick={handleGoogleSignup}
-            disabled={isLoading || success || isGoogleLoading}
-            className="w-full inline-flex justify-center items-center py-2.5 px-4 border border-slate-700 rounded-md shadow-sm bg-slate-800 text-sm font-medium text-slate-300 hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-neutral-900 focus:ring-blue-500 disabled:opacity-70 disabled:cursor-not-allowed">
-            {isGoogleLoading ? (
-              <>
-                <Loader size={18} className="animate-spin mr-2" />
-                Connecting to Google...
-              </>
-            ) : (
-              <>
-                <svg className="w-4 h-4 mr-2" viewBox="0 0 24 24">
-                  <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
-                  <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
-                  <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
-                  <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
-                </svg>
-                Sign up with Google
-              </>
-            )}
-          </button>
-        </div>
-      </div>
+      )}
 
       <div className="mt-6 text-center text-xs text-slate-400">
         Already have an account?{' '}

--- a/server/dashboard_react/src/types.ts
+++ b/server/dashboard_react/src/types.ts
@@ -29,3 +29,7 @@ export type HomeResponse =
   | { type: "CREATE_ORGANISATION"; name: string }
   | { type: "CREATE_APPLICATION"; organisation: string; name: string }
   | { type: "INVITE_USER"; organisation: string; email: string; role: string };
+
+export type Configuration = {
+  enableGoogleSignIn: boolean;
+}

--- a/server/dashboard_react/vite.config.ts
+++ b/server/dashboard_react/vite.config.ts
@@ -35,6 +35,10 @@ export default defineConfig(({ command }) => {
           usePolling: true,
         },
         proxy: {
+          '/dashboard/configuration': {
+            target: 'http://backend:9000',
+            changeOrigin: false,
+          },
           '/organisations': {
             target: 'http://backend:9000',
             changeOrigin: false,

--- a/server/src/dashboard/configuration/mod.rs
+++ b/server/src/dashboard/configuration/mod.rs
@@ -12,28 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use superposition_rust_sdk::Client;
+use actix_web::{get, web::{self, Json}, HttpRequest, Scope};
+use crate::types::AppState;
+use serde::{ Serialize, Deserialize };
 
-use crate::utils::db;
-
-#[derive(Clone)]
-pub struct AppState {
-    pub env: Environment,
-    pub db_pool: db::DbPool,
-    pub s3_client: aws_sdk_s3::Client,
-    pub superposition_client: Client,
+pub fn add_routes() -> Scope {
+    Scope::new("")
+        .service(get_global_configurations)
 }
 
-#[derive(Clone, Debug)]
-pub struct Environment {
-    pub public_url: String,
-    pub keycloak_url: String,
-    pub keycloak_external_url: String,
-    pub keycloak_public_key: String,
-    pub client_id: String,
-    pub secret: String,
-    pub realm: String,
-    pub bucket_name: String,
-    pub superposition_org_id: String,
-    pub enable_google_signin: bool,
+#[derive(Serialize, Deserialize)]
+struct Configuration {
+    google_signin_enabled: bool,
+}
+
+#[get("/")]
+async fn get_global_configurations(
+    _: HttpRequest,
+    state: web::Data<AppState>,
+) -> actix_web::Result<Json<Configuration>> {
+    
+    let config = Configuration {
+        google_signin_enabled: state.env.enable_google_signin,
+    };
+
+    Ok(Json(config))
 }

--- a/server/src/dashboard/mod.rs
+++ b/server/src/dashboard/mod.rs
@@ -12,12 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod configuration;
+
 use actix_files::Files;
 use actix_web::web;
 use actix_web::Scope;
 
 pub fn add_routes() -> Scope {
-    Scope::new("").service(
+    Scope::new("")
+    .service(
+        web::scope("/configuration")
+            .service(configuration::add_routes()),
+    )
+    .service(
         Files::new("/", "./dashboard_react/dist")
             .index_file("index.html")
             .default_handler(web::to(|| async {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -54,6 +54,10 @@ async fn main() -> std::io::Result<()> {
         .unwrap_or_else(|_| "9000".to_string())
         .parse()
         .expect("PORT must be a valid number");
+    let enable_google_signin = std::env::var("ENABLE_GOOGLE_SIGNIN")
+        .unwrap_or_else(|_| "false".to_string())
+        .parse::<bool>()
+        .unwrap_or(false);
 
     //Need to check if this ENV exists on pod
     let uses_local_stack = std::env::var("AWS_ENDPOINT_URL");
@@ -86,6 +90,7 @@ async fn main() -> std::io::Result<()> {
         realm,
         bucket_name,
         superposition_org_id: superposition_org_id_env,
+        enable_google_signin: enable_google_signin
     };
 
     // This is required for localStack

--- a/server/src/user/mod.rs
+++ b/server/src/user/mod.rs
@@ -422,6 +422,9 @@ async fn get_oauth_url(
     state: web::Data<AppState>,
 ) -> actix_web::Result<Json<serde_json::Value>> {
     // Use external URL directly from config
+    if !state.env.enable_google_signin {
+        return Err(error::ErrorBadRequest("Google Sign-in is disabled"));
+    }
     let keycloak_url = &state.env.keycloak_external_url;
     let realm = &state.env.realm;
     let client_id = &state.env.client_id;
@@ -511,6 +514,9 @@ async fn oauth_login(
     json_req: Json<OAuthLoginRequest>,
     state: web::Data<AppState>,
 ) -> actix_web::Result<Json<User>> {
+    if !state.env.enable_google_signin {
+        return Err(error::ErrorBadRequest("Google Sign-in is disabled"));
+    }
     println!("[OAUTH_LOGIN] Processing OAuth login with code");
 
     let oauth_req = json_req.into_inner();
@@ -574,6 +580,9 @@ async fn oauth_signup(
     json_req: Json<OAuthRequest>,
     state: web::Data<AppState>,
 ) -> actix_web::Result<Json<User>> {
+    if !state.env.enable_google_signin {
+        return Err(error::ErrorBadRequest("Google Sign-in is disabled"));
+    }
     println!("[OAUTH_SIGNUP] Processing OAuth signup with code");
 
     let oauth_req = json_req.into_inner();


### PR DESCRIPTION
## Summary

This PR introduces a new `/dashboard/configuration` endpoint that provides global dashboard configuration settings, starting with the ability to toggle Google Sign-In functionality through environment variables.

## Changes Made

### 1. New Dashboard Configuration Module (`src/dashboard/configuration/mod.rs`)
- **Endpoint**: `GET /dashboard/configuration/`
- **Purpose**: Returns global dashboard configuration settings for the application
- **Response Format**:
  ```json
  {
    "google_signin_enabled": true|false
  }
  ```

### 2. Environment Variable Integration
- **Variable**: `ENABLE_GOOGLE_SIGNIN`
- **Default**: `false` (if not set or invalid)
- **Type**: Boolean (`true`/`false`)
- **Usage**: Controls whether Google Sign-In is available in the frontend

## Technical Details

### Route Structure
```
/dashboard/configuration/
├── GET / → Returns global configuration
```

This dashboard configuration endpoint can be extended to include:
- Feature flags for other authentication providers
- UI theme settings
- Regional configurations
- Experimental feature toggles

## Security Notes

- Endpoint is intentionally public (no authentication required)
- Only exposes boolean flags, no sensitive configuration
- No user-specific data included in response