### PR TITLE
fix: add cleanup after native update

### DIFF
--- a/airborne-react-native/android/src/main/java/in/juspay/airborneplugin/Airborne.kt
+++ b/airborne-react-native/android/src/main/java/in/juspay/airborneplugin/Airborne.kt
@@ -1,6 +1,8 @@
 package `in`.juspay.airborneplugin
 
 import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
 import androidx.annotation.Keep
 import `in`.juspay.airborne.HyperOTAServices
 import `in`.juspay.airborne.LazyDownloadCallback
@@ -46,14 +48,31 @@ class Airborne(
         }
     }
 
-    private val hyperOTAServices = HyperOTAServices(
-        context,
-        airborneInterface.getNamespace(),
-        "",
-        releaseConfigUrl,
-        trackerCallback,
-        this::bootComplete
-    )
+    private val hyperOTAServices = run {
+        val appVersion = try {
+            val packageInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                context.packageManager.getPackageInfo(
+                    context.packageName,
+                    PackageManager.PackageInfoFlags.of(0)
+                )
+            } else {
+                @Suppress("DEPRECATION")
+                context.packageManager.getPackageInfo(context.packageName, 0)
+            }
+            packageInfo.versionName ?: ""
+        } catch (_: Exception) {
+            ""
+        }
+
+        HyperOTAServices(
+            context,
+            airborneInterface.getNamespace(),
+            appVersion,
+            releaseConfigUrl,
+            trackerCallback,
+            this::bootComplete
+        )
+    }
 
     private val applicationManager = hyperOTAServices.createApplicationManager(airborneInterface.getDimensions())
 

--- a/airborne-react-native/ios/AirborneReact.mm
+++ b/airborne-react-native/ios/AirborneReact.mm
@@ -1,8 +1,6 @@
 #import "AirborneReact.h"
 #import "Airborne.h"
 #import <React/RCTLog.h>
-#import <Airborne/AJPLoggerDelegate.h>
-#import <Airborne/AJPApplicationManager.h>
 #import <Airborne/Airborne-Swift.h>
 
 @implementation AirborneReact

--- a/airborne_sdk_iOS/hyper-ota/Airborne/AirborneSwift/AJPApplicationManager.swift
+++ b/airborne_sdk_iOS/hyper-ota/Airborne/AirborneSwift/AJPApplicationManager.swift
@@ -276,6 +276,22 @@ public typealias AJPReleaseConfigCompletionHandler = (AJPApplicationManifest?, E
         }
         
         self.utils = AJPApplicationManagerUtils(fileUtil: self.fileUtil, tracker: self.tracker, remoteFileUtil: self.remoteFileUtil)
+
+        let majorVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+        let minorVersion = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""
+        let appVersion = "\(majorVersion).\(minorVersion)"
+
+        let storedVersion = UserDefaults.standard.string(forKey: AJPApplicationConstants.APP_VERSION_USER_DEFAULTS_KEY)
+        if let storedVersion = storedVersion, storedVersion != appVersion {
+            self.utils.cleanupManifestDirectory()
+            self.utils.cleanupPackageDirectory()
+            let cleanupLog = NSMutableDictionary()
+            cleanupLog["previous_version"] = storedVersion
+            cleanupLog["current_version"] = appVersion
+            self.tracker.trackInfo("app_version_changed_cleanup", value: cleanupLog)
+        }
+
+        UserDefaults.standard.set(appVersion, forKey: AJPApplicationConstants.APP_VERSION_USER_DEFAULTS_KEY)
         
         // Handle if any previously downloaded packages are available.
         self.handleTempPackageInstallation()

--- a/airborne_sdk_iOS/hyper-ota/Airborne/AirborneSwift/AJPApplicationManagerUtils.swift
+++ b/airborne_sdk_iOS/hyper-ota/Airborne/AirborneSwift/AJPApplicationManagerUtils.swift
@@ -48,7 +48,15 @@ class AJPApplicationManagerUtils {
             try? fileManager.removeItem(atPath: tempDirPath)
         }
     }
-    
+
+    func cleanupPackageDirectory() {
+        fileUtil.cleanupEntireDirectory(AJPApplicationConstants.JUSPAY_PACKAGE_DIR)
+    }
+
+    func cleanupManifestDirectory() {
+        fileUtil.cleanupEntireDirectory(AJPApplicationConstants.JUSPAY_MANIFEST_DIR)
+    }
+
     // MARK: - File System Helpers
     
     func getAllFilesInDirectory(_ directory: String, subFolder: String, includeSubfolders: Bool) -> [String] {

--- a/airborne_sdk_iOS/hyper-ota/Airborne/AirborneSwiftCore/AJPFileUtil.swift
+++ b/airborne_sdk_iOS/hyper-ota/Airborne/AirborneSwiftCore/AJPFileUtil.swift
@@ -246,4 +246,22 @@ import Foundation
         let path = fullPathInStorageForFilePath(fileName, inFolder: folder)
         try FileManager.default.removeItem(atPath: path)
     }
+
+    /// Removes an entire top-level directory from the application's Library folder.
+    /// Unlike workspace-scoped deletions, this does not insert the workspace segment.
+    /// - Parameter dirName: The name of the directory to remove (e.g. "JuspayManifests").
+    @objc public func cleanupEntireDirectory(_ dirName: String) {
+        let paths = NSSearchPathForDirectoriesInDomains(.libraryDirectory, .userDomainMask, true)
+        guard var rootPath = paths.first else { return }
+
+        let subPaths = dirName.components(separatedBy: "/")
+        for subPath in subPaths {
+            rootPath = (rootPath as NSString).appendingPathComponent(subPath)
+        }
+
+        let fileManager = FileManager.default
+        if fileManager.fileExists(atPath: rootPath) {
+            try? fileManager.removeItem(atPath: rootPath)
+        }
+    }
 }

--- a/airborne_sdk_iOS/hyper-ota/Airborne/AirborneSwiftModel/AJPApplicationConstants.swift
+++ b/airborne_sdk_iOS/hyper-ota/Airborne/AirborneSwiftModel/AJPApplicationConstants.swift
@@ -35,6 +35,9 @@ import Foundation
     public static let RELEASE_CONFIG_TIMEOUT_NOTIFICATION = Notification.Name("AJPReleaseConfigTimeoutNotification")
     public static let LAZY_PACKAGE_NOTIFICATION = Notification.Name("AJPLazyPackageNotification")
 
+    // MARK: - UserDefaults Keys
+    public static let APP_VERSION_USER_DEFAULTS_KEY = "in.juspay.airborne.appVersion"
+
     // MARK: - Misc
     public static let APPL_MANAGER_SUB_CAT = "hyperota"
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * App version is now dynamically detected at runtime on both Android and iOS platforms
  * Automatic cleanup of cached data and package directories is triggered when the app version changes
  * Version change events are logged for diagnostic and tracking purposes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/juspay/airborne/pull/321?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->