### PR TITLE
feat: accept content encoding in file uploads

### DIFF
--- a/airborne_server/src/file.rs
+++ b/airborne_server/src/file.rs
@@ -717,6 +717,10 @@ async fn upload_file(
         .map_err(|_| ABError::BadRequest("Invalid x-checksum header".to_string()))?
         .to_string();
 
+    let content_encoding = utils::validate_content_encoding(
+        req.headers().get(actix_web::http::header::CONTENT_ENCODING),
+    )?;
+
     if file_path_str.is_empty() {
         info!("Rejected upload: empty file_path");
         return Err(ABError::BadRequest("File path cannot be empty".to_string()));
@@ -869,6 +873,7 @@ async fn upload_file(
             s3_path_clone,
             file_size,
             b64_fc.clone(),
+            content_encoding,
         )
         .await
     });

--- a/airborne_server/src/file/utils.rs
+++ b/airborne_server/src/file/utils.rs
@@ -1,4 +1,5 @@
 use base64::{engine::general_purpose, Engine as _};
+use http::HeaderValue;
 use log::info;
 use sha2::{Digest, Sha256 as checksum_algorithm};
 
@@ -87,4 +88,29 @@ pub fn base64_to_hex(value: &str) -> String {
         Ok(bytes) => hex::encode(bytes),
         Err(_) => String::new(), // return empty string on invalid base64
     }
+}
+
+pub fn validate_content_encoding(
+    header: Option<&HeaderValue>,
+) -> airborne_types::Result<Option<String>> {
+    const ALLOWED_ENCODINGS: [&str; 4] = ["gzip", "br", "zstd", "deflate"];
+
+    let encoding = header
+        .map(|v| v.to_str())
+        .transpose()
+        .map_err(|_| ABError::BadRequest("Invalid Content-Encoding header".to_string()))?
+        .map(|v| v.trim().to_ascii_lowercase())
+        .filter(|v| !v.is_empty());
+
+    if let Some(encoding) = &encoding {
+        if !ALLOWED_ENCODINGS.contains(&encoding.as_str()) {
+            return Err(ABError::BadRequest(format!(
+                "Unsupported Content-Encoding '{}'. Allowed values: {}",
+                encoding,
+                ALLOWED_ENCODINGS.join(", ")
+            )));
+        }
+    }
+
+    Ok(encoding)
 }

--- a/airborne_server/src/utils/s3.rs
+++ b/airborne_server/src/utils/s3.rs
@@ -32,6 +32,7 @@ pub async fn stream_file(
     filename: String,
     file_size: i64,
     checksum: String,
+    content_encoding: Option<String>,
 ) -> airborne_types::Result<PutObjectOutput> {
     info!("Uploading file: {}", filename);
     info!("Uploading File: {}", file_size);
@@ -40,6 +41,7 @@ pub async fn stream_file(
         .bucket(bucket_name)
         .key(filename.clone())
         .content_length(file_size)
+        .set_content_encoding(content_encoding)
         .set_checksum_sha256(Some(checksum))
         .set_checksum_algorithm(Some(ChecksumAlgorithm::Sha256))
         .body(byte_stream)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * File uploads now properly support and preserve Content-Encoding metadata. Supported encodings include gzip, br, zstd, and deflate, ensuring correctly labeled file storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->