### PR TITLE
feat: service accounts

### DIFF
--- a/airborne_dashboard/app/dashboard/[orgId]/users/page.tsx
+++ b/airborne_dashboard/app/dashboard/[orgId]/users/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import React, { useState, useMemo, useEffect } from "react";
 import useSWR from "swr";
 import { apiFetch } from "@/lib/api";
 import { useAppContext } from "@/providers/app-context";
@@ -11,10 +12,54 @@ import {
 } from "@/components/user-management";
 import { definePagePermissions, permission } from "@/lib/page-permissions";
 import { usePagePermissions } from "@/hooks/use-page-permissions";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Bot, Download, Trash2, Plus, RefreshCw, AlertTriangle } from "lucide-react";
+import { toastSuccess } from "@/hooks/use-toast";
 
 type OrgUsers = { users: User[] };
 type RoleListResponse = { roles: RoleOption[] };
 type PermissionListResponse = { permissions: PermissionOption[] };
+
+interface ServiceAccount {
+  client_id: string;
+  name: string;
+  email: string;
+  description: string;
+  created_by: string;
+  created_at: string;
+}
+
+interface ServiceAccountListResponse {
+  data: ServiceAccount[];
+}
+
+interface CreateServiceAccountResponse {
+  client_id: string;
+  client_secret: string;
+  email: string;
+  name: string;
+}
+
+interface RotateServiceAccountResponse {
+  client_id: string;
+  client_secret: string;
+}
+
+function formatRoleLabel(role: string): string {
+  return (
+    role
+      .split(/[_-]/)
+      .filter(Boolean)
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(" ") || role
+  );
+}
 
 const PAGE_AUTHZ = definePagePermissions({
   read_users: permission("organisation_user", "read", "org"),
@@ -24,23 +69,447 @@ const PAGE_AUTHZ = definePagePermissions({
   transfer_ownership: permission("organisation_user", "transfer", "org"),
   read_roles: permission("organisation_role", "read", "org"),
   create_roles: permission("organisation_role", "create", "org"),
+  create_service_account: permission("service_account", "create", "org"),
+  read_service_account: permission("service_account", "read", "org"),
+  delete_service_account: permission("service_account", "delete", "org"),
 });
+
+function ServiceAccountCredentialsDisplay({
+  clientId,
+  clientSecret,
+  name,
+  email,
+  organisation,
+}: {
+  clientId: string;
+  clientSecret: string;
+  name?: string;
+  email?: string;
+  organisation?: string;
+}) {
+  const downloadAsJson = () => {
+    const tokenEndpoint = `${window.location.origin}/api/token/issue`;
+    const data = {
+      type: "service_account",
+      name: name || undefined,
+      email: email || undefined,
+      organisation: organisation || undefined,
+      client_id: clientId,
+      client_secret: clientSecret,
+      token_endpoint: tokenEndpoint,
+    };
+    const blob = new Blob([JSON.stringify(data, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${name || "service-account"}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="space-y-4">
+      <Alert variant="destructive">
+        <AlertTriangle className="h-4 w-4" />
+        <AlertDescription>Download the credentials now. The client secret will not be shown again.</AlertDescription>
+      </Alert>
+
+      {email && (
+        <div>
+          <label className="text-sm font-medium text-muted-foreground">Email</label>
+          <code className="mt-1 block rounded bg-muted px-3 py-2 text-sm font-mono break-all">{email}</code>
+        </div>
+      )}
+
+      <Button variant="outline" className="w-full" onClick={downloadAsJson}>
+        <Download className="h-4 w-4 mr-2" />
+        Download as JSON
+      </Button>
+    </div>
+  );
+}
+
+function ServiceAccountsSection({
+  canCreate,
+  canDelete,
+  canRead,
+  roles,
+  token,
+  org,
+}: {
+  canCreate: boolean;
+  canDelete: boolean;
+  canRead: boolean;
+  roles: RoleOption[];
+  token: string | null;
+  org: string | null;
+}) {
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [isRotateDialogOpen, setIsRotateDialogOpen] = useState(false);
+  const [newCredentials, setNewCredentials] = useState<CreateServiceAccountResponse | null>(null);
+  const [rotatedCredentials, setRotatedCredentials] = useState<RotateServiceAccountResponse | null>(null);
+  const [accountToDelete, setAccountToDelete] = useState<ServiceAccount | null>(null);
+  const [accountToRotate, setAccountToRotate] = useState<ServiceAccount | null>(null);
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [role, setRole] = useState("read");
+  const [isCreating, setIsCreating] = useState(false);
+  const [isRotating, setIsRotating] = useState(false);
+
+  // Assignable roles come from the org's role list (owner is not assignable to a
+  // service account); fall back to the built-in roles when none are loaded.
+  const roleValues = useMemo(() => {
+    const dynamic = roles.map((entry) => entry.role).filter((entry) => entry && entry !== "owner");
+    return dynamic.length > 0 ? dynamic : ["admin", "write", "read"];
+  }, [roles]);
+
+  // Keep the selected role valid whenever the available roles change.
+  useEffect(() => {
+    if (!roleValues.includes(role)) {
+      setRole(roleValues.includes("read") ? "read" : (roleValues[0] ?? "read"));
+    }
+  }, [roleValues, role]);
+
+  const { data, mutate } = useSWR<ServiceAccountListResponse>(
+    token && org && canRead ? ["/service-accounts", org] : null,
+    () => apiFetch<ServiceAccountListResponse>("/service-accounts", {}, { token, org })
+  );
+
+  const handleCreate = async () => {
+    if (!name.trim()) return;
+    setIsCreating(true);
+    try {
+      const result = await apiFetch<CreateServiceAccountResponse>(
+        "/service-accounts",
+        { method: "POST", body: { name: name.trim(), description, role } },
+        { token, org }
+      );
+      setNewCredentials(result);
+      mutate();
+      toastSuccess("Service Account Created", `Service account '${result.name}' created successfully`);
+    } catch {
+      // Error handled by apiFetch
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!accountToDelete) return;
+    try {
+      await apiFetch(`/service-accounts/${accountToDelete.client_id}`, { method: "DELETE" }, { token, org });
+      mutate();
+      setIsDeleteDialogOpen(false);
+      setAccountToDelete(null);
+      toastSuccess("Service Account Deleted", `Service account '${accountToDelete.name}' has been deleted`);
+    } catch {
+      // Error handled by apiFetch
+    }
+  };
+
+  const handleRotate = async () => {
+    // Rotation is non-idempotent (recreates the identity), so ignore repeat
+    // clicks while a request is already in flight.
+    if (!accountToRotate || isRotating) return;
+    setIsRotating(true);
+    try {
+      const result = await apiFetch<RotateServiceAccountResponse>(
+        `/service-accounts/${accountToRotate.client_id}/rotate`,
+        { method: "POST" },
+        { token, org }
+      );
+      setRotatedCredentials(result);
+      toastSuccess("Credentials Rotated", `New credentials generated for '${accountToRotate.name}'`);
+    } catch {
+      // Error handled by apiFetch
+    } finally {
+      setIsRotating(false);
+    }
+  };
+
+  const resetCreateDialog = () => {
+    setIsCreateDialogOpen(false);
+    setNewCredentials(null);
+    setName("");
+    setDescription("");
+    setRole("read");
+  };
+
+  const resetRotateDialog = () => {
+    setIsRotateDialogOpen(false);
+    setRotatedCredentials(null);
+    setAccountToRotate(null);
+  };
+
+  const accounts = data?.data ?? [];
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle>Service Accounts</CardTitle>
+            <p className="text-sm text-muted-foreground mt-1">
+              Manage service accounts for programmatic access to this organisation
+            </p>
+          </div>
+          {canCreate && (
+            <Dialog
+              open={isCreateDialogOpen}
+              onOpenChange={(open) => {
+                if (!open) resetCreateDialog();
+                else setIsCreateDialogOpen(true);
+              }}
+            >
+              <DialogTrigger asChild>
+                <Button>
+                  <Plus className="h-4 w-4 mr-2" />
+                  Create Service Account
+                </Button>
+              </DialogTrigger>
+              <DialogContent className="max-w-lg">
+                <DialogHeader>
+                  <DialogTitle>{newCredentials ? "Service Account Created" : "Create Service Account"}</DialogTitle>
+                </DialogHeader>
+
+                {newCredentials ? (
+                  <div className="space-y-4">
+                    <ServiceAccountCredentialsDisplay
+                      clientId={newCredentials.client_id}
+                      clientSecret={newCredentials.client_secret}
+                      name={newCredentials.name}
+                      email={newCredentials.email}
+                      organisation={org ?? undefined}
+                    />
+                    <div className="flex justify-end">
+                      <Button onClick={resetCreateDialog}>Done</Button>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="space-y-4">
+                    <div>
+                      <label className="text-sm font-medium">Name</label>
+                      <Input
+                        className="mt-2"
+                        placeholder="e.g. ci-deploy"
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                      />
+                      <p className="text-xs text-muted-foreground mt-1">
+                        Lowercase letters, numbers, hyphens, and underscores only
+                      </p>
+                    </div>
+                    <div>
+                      <label className="text-sm font-medium">Description (optional)</label>
+                      <Input
+                        className="mt-2"
+                        placeholder="e.g. CI/CD pipeline access"
+                        value={description}
+                        onChange={(e) => setDescription(e.target.value)}
+                      />
+                    </div>
+                    <div>
+                      <label className="text-sm font-medium">Role</label>
+                      <Select value={role} onValueChange={setRole}>
+                        <SelectTrigger className="mt-2">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {roleValues.map((roleValue) => (
+                            <SelectItem key={roleValue} value={roleValue}>
+                              {formatRoleLabel(roleValue)}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="flex justify-end gap-2">
+                      <Button variant="outline" onClick={resetCreateDialog}>
+                        Cancel
+                      </Button>
+                      <Button onClick={handleCreate} disabled={!name.trim() || isCreating}>
+                        {isCreating ? "Creating..." : "Create"}
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </DialogContent>
+            </Dialog>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-2">
+          {accounts.length === 0 ? (
+            <div className="py-8 text-center text-muted-foreground">No service accounts found.</div>
+          ) : (
+            accounts.map((account) => (
+              <div
+                key={account.client_id}
+                className="flex items-center justify-between rounded-lg border p-4 transition-colors hover:bg-muted/50"
+              >
+                <div className="flex items-center gap-3">
+                  <div className="h-8 w-8 rounded-full bg-orange-100 dark:bg-orange-900 flex items-center justify-center">
+                    <Bot className="h-4 w-4 text-orange-600 dark:text-orange-300" />
+                  </div>
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <p className="font-medium">{account.name}</p>
+                      <Badge
+                        variant="outline"
+                        className="text-xs bg-orange-50 text-orange-700 border-orange-200 dark:bg-orange-950 dark:text-orange-300 dark:border-orange-800"
+                      >
+                        Service Account
+                      </Badge>
+                    </div>
+                    <p className="text-xs text-muted-foreground">{account.email}</p>
+                    {account.description && (
+                      <p className="text-xs text-muted-foreground mt-0.5">{account.description}</p>
+                    )}
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-muted-foreground">
+                    Created {new Date(account.created_at).toLocaleDateString()}
+                  </span>
+                  {canCreate && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      title="Rotate credentials"
+                      onClick={() => {
+                        setAccountToRotate(account);
+                        setRotatedCredentials(null);
+                        setIsRotateDialogOpen(true);
+                      }}
+                    >
+                      <RefreshCw className="h-4 w-4" />
+                    </Button>
+                  )}
+                  {canDelete && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-destructive hover:text-destructive"
+                      title="Delete service account"
+                      onClick={() => {
+                        setAccountToDelete(account);
+                        setIsDeleteDialogOpen(true);
+                      }}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  )}
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </CardContent>
+
+      {/* Delete confirmation dialog */}
+      <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Service Account</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              Are you sure you want to delete the service account <strong>{accountToDelete?.name}</strong>? This will
+              revoke all access immediately. This action cannot be undone.
+            </p>
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setIsDeleteDialogOpen(false);
+                  setAccountToDelete(null);
+                }}
+              >
+                Cancel
+              </Button>
+              <Button variant="destructive" onClick={handleDelete}>
+                <Trash2 className="h-4 w-4 mr-2" />
+                Delete
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Rotate credentials dialog */}
+      <Dialog
+        open={isRotateDialogOpen}
+        onOpenChange={(open) => {
+          if (!open) resetRotateDialog();
+        }}
+      >
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{rotatedCredentials ? "New Credentials" : "Rotate Credentials"}</DialogTitle>
+          </DialogHeader>
+          {rotatedCredentials ? (
+            <div className="space-y-4">
+              <ServiceAccountCredentialsDisplay
+                clientId={rotatedCredentials.client_id}
+                clientSecret={rotatedCredentials.client_secret}
+                name={accountToRotate?.name}
+                email={accountToRotate?.email}
+                organisation={org ?? undefined}
+              />
+              <div className="flex justify-end">
+                <Button onClick={resetRotateDialog}>Done</Button>
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <p className="text-sm text-muted-foreground">
+                This will generate new credentials for <strong>{accountToRotate?.name}</strong>. The old credentials
+                will stop working immediately.
+              </p>
+              <div className="flex justify-end gap-2">
+                <Button variant="outline" onClick={resetRotateDialog}>
+                  Cancel
+                </Button>
+                <Button onClick={handleRotate} disabled={isRotating}>
+                  <RefreshCw className="h-4 w-4 mr-2" />
+                  {isRotating ? "Rotating..." : "Rotate"}
+                </Button>
+              </div>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+}
 
 export default function OrganisationUsersPage() {
   const { token, org, updateOrgs } = useAppContext();
   const permissions = usePagePermissions(PAGE_AUTHZ);
   const canReadRoles = permissions.can("read_roles");
   const canCreateRoles = permissions.can("create_roles");
-  const { data, error, mutate } = useSWR<OrgUsers>(token && org ? "/organisations/user/list" : null, (url: string) =>
-    apiFetch<any>(url, {}, { token, org })
+  const canManageServiceAccounts = permissions.can("create_service_account") || permissions.can("read_service_account");
+
+  const { data, error, mutate } = useSWR<OrgUsers>(token && org ? ["/organisations/user/list", org] : null, () =>
+    apiFetch<any>("/organisations/user/list", {}, { token, org })
   );
   const { data: roleData, mutate: mutateRoles } = useSWR<RoleListResponse>(
-    token && org && canReadRoles ? "/organisations/user/roles/list" : null,
-    (url: string) => apiFetch<RoleListResponse>(url, {}, { token, org })
+    token && org && canReadRoles ? ["/organisations/user/roles/list", org] : null,
+    () => apiFetch<RoleListResponse>("/organisations/user/roles/list", {}, { token, org })
   );
   const { data: permissionData } = useSWR<PermissionListResponse>(
-    token && org && canReadRoles ? "/organisations/user/permissions/list" : null,
-    (url: string) => apiFetch<PermissionListResponse>(url, {}, { token, org })
+    token && org && canReadRoles ? ["/organisations/user/permissions/list", org] : null,
+    () => apiFetch<PermissionListResponse>("/organisations/user/permissions/list", {}, { token, org })
+  );
+
+  // Filter out service account users from the regular users list
+  const regularUsers = (data?.users || []).filter(
+    (user) => !user.username.endsWith("@service-account.airborne.juspay.in")
   );
 
   const addUser = async (user: string, access: AccessLevel) => {
@@ -81,9 +550,9 @@ export default function OrganisationUsersPage() {
   }
 
   return (
-    <div className="container mx-auto p-6">
+    <div className="container mx-auto p-6 space-y-6">
       <UserManagement
-        users={data?.users || []}
+        users={regularUsers}
         canAddUser={permissions.can("create_user")}
         canUpdateUser={permissions.can("update_user")}
         canRemoveUser={permissions.can("delete_user")}
@@ -100,6 +569,17 @@ export default function OrganisationUsersPage() {
         description="Manage users and their access levels for this organisation"
         entityType="organisation"
       />
+
+      {canManageServiceAccounts && (
+        <ServiceAccountsSection
+          canCreate={permissions.can("create_service_account")}
+          canDelete={permissions.can("delete_service_account")}
+          canRead={permissions.can("read_service_account")}
+          roles={roleData?.roles || []}
+          token={token}
+          org={org}
+        />
+      )}
     </div>
   );
 }

--- a/airborne_dashboard/next.config.mjs
+++ b/airborne_dashboard/next.config.mjs
@@ -15,7 +15,8 @@ const nextConfig = {
         destination: `https://airborne.juspay.in/analytics/:path*`,
       },
       {
-        source: "/api/:api(releases|file|organisations|applications|users|packages|dashboard|token|authz)/:path*",
+        source:
+          "/api/:api(releases|file|organisations|applications|users|packages|dashboard|token|authz|service-accounts)/:path*",
         destination: `${backend}/api/:api/:path*`,
       },
       {

--- a/airborne_server/migrations/20260410120000_add_service_accounts/down.sql
+++ b/airborne_server/migrations/20260410120000_add_service_accounts/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS hyperotaserver.service_accounts;

--- a/airborne_server/migrations/20260410120000_add_service_accounts/up.sql
+++ b/airborne_server/migrations/20260410120000_add_service_accounts/up.sql
@@ -1,0 +1,14 @@
+CREATE TABLE hyperotaserver.service_accounts (
+    client_id UUID PRIMARY KEY,
+    name TEXT NOT NULL,
+    email TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    organisation TEXT NOT NULL,
+    created_by TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    encrypted_refresh_token TEXT NOT NULL DEFAULT '',
+    UNIQUE (email),
+    UNIQUE (organisation, name)
+);
+
+CREATE INDEX idx_service_accounts_org ON hyperotaserver.service_accounts (organisation);

--- a/airborne_server/src/main.rs
+++ b/airborne_server/src/main.rs
@@ -26,6 +26,7 @@ mod organisation;
 mod package;
 mod provider;
 mod release;
+mod service_account;
 mod token;
 mod types;
 mod user;
@@ -534,6 +535,11 @@ async fn main() -> std::io::Result<()> {
                     )
                     .service(user::add_routes("users"))
                     .service(token::add_scopes("token"))
+                    .service(
+                        web::scope("/service-accounts")
+                            .wrap(Auth)
+                            .service(service_account::add_routes()),
+                    )
                     .service(web::scope("/file").wrap(Auth).service(file::add_routes()))
                     .service(
                         web::scope("/packages")

--- a/airborne_server/src/organisation/user.rs
+++ b/airborne_server/src/organisation/user.rs
@@ -69,6 +69,16 @@ async fn organisation_add_user(
     let (organisation, auth) = get_org_context(&req).await?;
     let role_name = body.access.trim();
 
+    // Reject service account emails — they must be managed via the service accounts API
+    let user_lower = body.user.trim().to_ascii_lowercase();
+    let service_account_suffix =
+        format!("@{}", crate::service_account::SERVICE_ACCOUNT_EMAIL_DOMAIN);
+    if user_lower.ends_with(&service_account_suffix) {
+        return Err(ABError::BadRequest(
+            "Service account emails cannot be added as regular users. Use the service accounts API instead.".to_string(),
+        ));
+    }
+
     state
         .authz_provider
         .add_organisation_user(

--- a/airborne_server/src/provider/authn.rs
+++ b/airborne_server/src/provider/authn.rs
@@ -470,6 +470,42 @@ pub trait AuthNProvider: Send + Sync {
     ) -> airborne_types::Result<TokenData<AuthnTokenClaims>> {
         verify_authn_token(access_token, &state.env).await
     }
+
+    fn supports_service_accounts(&self) -> bool {
+        false
+    }
+
+    async fn create_service_account_user(
+        &self,
+        _state: &AppState,
+        _username: &str,
+        _email: &str,
+        _password: &str,
+    ) -> airborne_types::Result<UserToken> {
+        Err(ABError::BadRequest(
+            "Service accounts are not supported for configured AuthN provider".to_string(),
+        ))
+    }
+
+    /// Rotate an existing service account identity's credentials: set a fresh
+    /// password, revoke any outstanding sessions/tokens, and return a new
+    /// offline token — without deleting/recreating the underlying user.
+    async fn rotate_service_account_user(
+        &self,
+        _state: &AppState,
+        _username: &str,
+        _password: &str,
+    ) -> airborne_types::Result<UserToken> {
+        Err(ABError::BadRequest(
+            "Service accounts are not supported for configured AuthN provider".to_string(),
+        ))
+    }
+
+    async fn delete_user(&self, _state: &AppState, _username: &str) -> airborne_types::Result<()> {
+        Err(ABError::BadRequest(
+            "User deletion is not supported for configured AuthN provider".to_string(),
+        ))
+    }
 }
 
 pub fn build_authn_provider(kind: AuthnProviderKind) -> Arc<dyn AuthNProvider> {

--- a/airborne_server/src/provider/authn/keycloak.rs
+++ b/airborne_server/src/provider/authn/keycloak.rs
@@ -166,4 +166,184 @@ impl AuthNProvider for KeycloakAuthNProvider {
 
         self.login_with_password(state, credentials).await
     }
+
+    fn supports_service_accounts(&self) -> bool {
+        true
+    }
+
+    async fn create_service_account_user(
+        &self,
+        state: &AppState,
+        username: &str,
+        email: &str,
+        password: &str,
+    ) -> airborne_types::Result<UserToken> {
+        if state.env.keycloak_url.trim().is_empty() {
+            return Err(ABError::InternalServerError(
+                "AUTH_ADMIN_ISSUER must be configured for service account creation".to_string(),
+            ));
+        }
+        if state.env.realm.trim().is_empty() {
+            return Err(ABError::InternalServerError(
+                "Unable to derive Keycloak realm from AUTH_ADMIN_ISSUER".to_string(),
+            ));
+        }
+
+        let admin_token = get_token(state.env.clone(), Client::new())
+            .await
+            .map_err(|_| ABError::InternalServerError("Failed to get admin token".to_string()))?;
+        let admin = KeycloakAdmin::new(&state.env.keycloak_url, admin_token, Client::new());
+
+        if find_user_by_username(&admin, &state.env.realm, username)
+            .await?
+            .is_some()
+        {
+            return Err(ABError::BadRequest(
+                "Service account user already exists".to_string(),
+            ));
+        }
+
+        let user = UserRepresentation {
+            username: Some(username.to_string()),
+            first_name: Some("Service".to_string()),
+            last_name: Some("Account".to_string()),
+            email: Some(email.to_string()),
+            email_verified: Some(true),
+            credentials: Some(vec![CredentialRepresentation {
+                value: Some(password.to_string()),
+                temporary: Some(false),
+                type_: Some("password".to_string()),
+                ..Default::default()
+            }]),
+            enabled: Some(true),
+            ..Default::default()
+        };
+        admin.realm_users_post(&state.env.realm, user).await?;
+
+        // Login with offline_access to get a long-lived refresh token
+        let credentials = UserCredentials {
+            name: username.to_string(),
+            password: password.to_string(),
+            first_name: None,
+            last_name: None,
+            email: None,
+        };
+        match password_login_common(state, &credentials, Some("offline_access")).await {
+            Ok(token) => Ok(token),
+            Err(e) => {
+                // Roll back the just-created Keycloak user so a retry is not blocked
+                // by an orphaned identity failing the duplicate-username check above.
+                if let Err(cleanup_err) = self.delete_user(state, username).await {
+                    log::error!(
+                        "Failed to roll back orphaned service account user '{}': {}",
+                        username,
+                        cleanup_err
+                    );
+                }
+                Err(e)
+            }
+        }
+    }
+
+    async fn rotate_service_account_user(
+        &self,
+        state: &AppState,
+        username: &str,
+        password: &str,
+    ) -> airborne_types::Result<UserToken> {
+        if state.env.keycloak_url.trim().is_empty() || state.env.realm.trim().is_empty() {
+            return Err(ABError::InternalServerError(
+                "Keycloak admin configuration required for service account rotation".to_string(),
+            ));
+        }
+
+        let admin_token = get_token(state.env.clone(), Client::new())
+            .await
+            .map_err(|_| ABError::InternalServerError("Failed to get admin token".to_string()))?;
+        let admin = KeycloakAdmin::new(&state.env.keycloak_url, admin_token, Client::new());
+
+        let user = find_user_by_username(&admin, &state.env.realm, username)
+            .await?
+            .ok_or_else(|| {
+                ABError::NotFound("Service account user not found in identity provider".to_string())
+            })?;
+        let user_id = user.id.ok_or_else(|| {
+            ABError::InternalServerError("User has no ID in identity provider".to_string())
+        })?;
+
+        // 1. Set a fresh password (admin reset does not require the old one).
+        admin
+            .realm_users_with_user_id_reset_password_put(
+                &state.env.realm,
+                &user_id,
+                CredentialRepresentation {
+                    value: Some(password.to_string()),
+                    temporary: Some(false),
+                    type_: Some("password".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .map_err(|e| {
+                ABError::InternalServerError(format!(
+                    "Failed to reset service account password: {}",
+                    e
+                ))
+            })?;
+
+        // 2. Revoke existing sessions so the previously issued offline token
+        //    (the old client_secret) can no longer be refreshed.
+        admin
+            .realm_users_with_user_id_logout_post(&state.env.realm, &user_id)
+            .await
+            .map_err(|e| {
+                ABError::InternalServerError(format!(
+                    "Failed to revoke service account sessions: {}",
+                    e
+                ))
+            })?;
+
+        // 3. Log in with offline_access to mint a fresh long-lived refresh token.
+        let credentials = UserCredentials {
+            name: username.to_string(),
+            password: password.to_string(),
+            first_name: None,
+            last_name: None,
+            email: None,
+        };
+        password_login_common(state, &credentials, Some("offline_access")).await
+    }
+
+    async fn delete_user(&self, state: &AppState, username: &str) -> airborne_types::Result<()> {
+        if state.env.keycloak_url.trim().is_empty() || state.env.realm.trim().is_empty() {
+            return Err(ABError::InternalServerError(
+                "Keycloak admin configuration required for user deletion".to_string(),
+            ));
+        }
+
+        let admin_token = get_token(state.env.clone(), Client::new())
+            .await
+            .map_err(|_| ABError::InternalServerError("Failed to get admin token".to_string()))?;
+        let admin = KeycloakAdmin::new(&state.env.keycloak_url, admin_token, Client::new());
+
+        let user = find_user_by_username(&admin, &state.env.realm, username)
+            .await?
+            .ok_or_else(|| ABError::NotFound("User not found in identity provider".to_string()))?;
+
+        let user_id = user.id.ok_or_else(|| {
+            ABError::InternalServerError("User has no ID in identity provider".to_string())
+        })?;
+
+        admin
+            .realm_users_with_user_id_delete(&state.env.realm, &user_id)
+            .await
+            .map_err(|e| {
+                ABError::InternalServerError(format!(
+                    "Failed to delete user from identity provider: {}",
+                    e
+                ))
+            })?;
+
+        Ok(())
+    }
 }

--- a/airborne_server/src/service_account.rs
+++ b/airborne_server/src/service_account.rs
@@ -1,0 +1,365 @@
+pub mod types;
+mod utils;
+
+use actix_web::{
+    delete, get, post,
+    web::{self, Json, ReqData},
+    HttpRequest, Scope,
+};
+use airborne_authz_macros::authz;
+use chrono::Utc;
+use diesel::prelude::*;
+use log::info;
+
+use crate::{
+    middleware::auth::AuthResponse,
+    run_blocking,
+    service_account::types::*,
+    service_account::utils::{
+        build_service_account_email, generate_random_password, get_org_context, mask_email,
+        validate_service_account_name,
+    },
+    types as airborne_types,
+    types::{ABError, AppState, ListResponse},
+    utils::{
+        db::{
+            models::ServiceAccountEntry,
+            schema::hyperotaserver::service_accounts::{
+                client_id as sa_client_id, encrypted_refresh_token as sa_encrypted_refresh_token,
+                organisation as sa_org, table as service_accounts_table,
+            },
+        },
+        encryption::{encrypt_string, generate_random_key},
+    },
+};
+
+const MAX_SERVICE_ACCOUNT_NAME_LENGTH: usize = 50;
+pub(crate) const SERVICE_ACCOUNT_EMAIL_DOMAIN: &str = "service-account.airborne.juspay.in";
+
+pub fn add_routes() -> Scope {
+    Scope::new("")
+        .service(create_service_account)
+        .service(list_service_accounts)
+        .service(delete_service_account)
+        .service(rotate_service_account)
+}
+
+#[authz(
+    resource = "service_account",
+    action = "create",
+    org_roles = ["owner", "admin"],
+    app_roles = []
+)]
+#[post("")]
+async fn create_service_account(
+    req: HttpRequest,
+    body: Json<CreateServiceAccountRequest>,
+    auth_response: ReqData<AuthResponse>,
+    state: web::Data<AppState>,
+) -> airborne_types::Result<Json<CreateServiceAccountResponse>> {
+    if !state.authn_provider.supports_service_accounts() {
+        return Err(ABError::BadRequest(
+            "Service accounts are not supported for configured AuthN provider".to_string(),
+        ));
+    }
+
+    let (organisation, auth) = get_org_context(&req).await?;
+    let body = body.into_inner();
+
+    let name = validate_service_account_name(&body.name)?;
+    let email = build_service_account_email(&name, &organisation);
+    let password = generate_random_password().await?;
+
+    // Create user in OIDC provider and get offline refresh token
+    let token = state
+        .authn_provider
+        .create_service_account_user(state.get_ref(), &name, &email, &password)
+        .await?;
+
+    let client_secret = generate_random_key().await?;
+    let encrypted_refresh_token = encrypt_string(&token.refresh_token, &client_secret).await?;
+
+    let client_uid = uuid::Uuid::new_v4();
+    let entry = ServiceAccountEntry {
+        client_id: client_uid,
+        name: name.clone(),
+        email: email.clone(),
+        description: body.description,
+        organisation: organisation.clone(),
+        created_by: auth.sub.clone(),
+        created_at: Utc::now(),
+        encrypted_refresh_token,
+    };
+
+    let pool = state.db_pool.clone();
+    let insert_result = run_blocking!({
+        let mut conn = pool.get()?;
+        diesel::insert_into(service_accounts_table)
+            .values(&entry)
+            .execute(&mut conn)
+            .map_err(|e| {
+                log::error!("[CREATE SERVICE ACCOUNT] DB insert failed: {}", e);
+                ABError::InternalServerError(format!("Failed to create service account: {}", e))
+            })?;
+        Ok(())
+    });
+    if let Err(e) = insert_result {
+        // Roll back the OIDC user created above (best effort) so it is not orphaned.
+        if let Err(cleanup_err) = state
+            .authn_provider
+            .delete_user(state.get_ref(), &name)
+            .await
+        {
+            log::error!(
+                "[CREATE SERVICE ACCOUNT] Failed to roll back OIDC user '{}' after DB insert failure: {}",
+                name,
+                cleanup_err
+            );
+        }
+        return Err(e);
+    }
+
+    // Add service account as org member with requested role
+    if let Err(e) = state
+        .authz_provider
+        .add_organisation_user(
+            state.get_ref(),
+            &auth.sub,
+            &organisation,
+            &email,
+            &body.role,
+        )
+        .await
+    {
+        // Roll back the DB row and OIDC user (best effort) so nothing is left orphaned.
+        let pool = state.db_pool.clone();
+        if let Err(cleanup_err) = run_blocking!({
+            let mut conn = pool.get()?;
+            diesel::delete(service_accounts_table.filter(sa_client_id.eq(&client_uid)))
+                .execute(&mut conn)
+                .ok();
+            Ok(())
+        }) {
+            log::error!(
+                "[CREATE SERVICE ACCOUNT] Failed to roll back DB row for '{}' after authz failure: {}",
+                name,
+                cleanup_err
+            );
+        }
+        if let Err(cleanup_err) = state
+            .authn_provider
+            .delete_user(state.get_ref(), &name)
+            .await
+        {
+            log::error!(
+                "[CREATE SERVICE ACCOUNT] Failed to roll back OIDC user '{}' after authz failure: {}",
+                name,
+                cleanup_err
+            );
+        }
+        return Err(e);
+    }
+
+    info!(
+        "Service account '{}' (id {}) created in org '{}' by '{}'",
+        name,
+        client_uid,
+        organisation,
+        mask_email(&auth.sub)
+    );
+
+    Ok(Json(CreateServiceAccountResponse {
+        client_id: client_uid,
+        client_secret,
+        email,
+        name,
+    }))
+}
+
+#[authz(
+    resource = "service_account",
+    action = "read",
+    org_roles = ["owner", "admin"],
+    app_roles = []
+)]
+#[get("")]
+async fn list_service_accounts(
+    req: HttpRequest,
+    auth_response: ReqData<AuthResponse>,
+    state: web::Data<AppState>,
+) -> airborne_types::Result<Json<ListResponse<Vec<ServiceAccountListEntry>>>> {
+    let (organisation, _auth) = get_org_context(&req).await?;
+
+    let pool = state.db_pool.clone();
+    let entries = run_blocking!({
+        let mut conn = pool.get()?;
+        service_accounts_table
+            .filter(sa_org.eq(&organisation))
+            .load::<ServiceAccountEntry>(&mut conn)
+            .map_err(|e| {
+                log::error!("[LIST SERVICE ACCOUNTS] DB fetch failed: {}", e);
+                ABError::InternalServerError(format!("Failed to list service accounts: {}", e))
+            })
+    })?;
+
+    let data = entries
+        .into_iter()
+        .map(|entry| ServiceAccountListEntry {
+            client_id: entry.client_id,
+            name: entry.name,
+            email: entry.email,
+            description: entry.description,
+            created_by: entry.created_by,
+            created_at: entry.created_at,
+        })
+        .collect();
+
+    Ok(Json(ListResponse { data }))
+}
+
+#[authz(
+    resource = "service_account",
+    action = "delete",
+    org_roles = ["owner", "admin"],
+    app_roles = []
+)]
+#[delete("/{client_id}")]
+async fn delete_service_account(
+    req: HttpRequest,
+    path: web::Path<uuid::Uuid>,
+    auth_response: ReqData<AuthResponse>,
+    state: web::Data<AppState>,
+) -> airborne_types::Result<Json<DeleteServiceAccountResponse>> {
+    let (organisation, auth) = get_org_context(&req).await?;
+    let target_client_id = path.into_inner();
+
+    // Load service account from DB
+    let pool = state.db_pool.clone();
+    let org_filter = organisation.clone();
+    let entry = run_blocking!({
+        let mut conn = pool.get()?;
+        service_accounts_table
+            .filter(sa_client_id.eq(&target_client_id))
+            .filter(sa_org.eq(&org_filter))
+            .first::<ServiceAccountEntry>(&mut conn)
+            .map_err(|_| ABError::NotFound("Service account not found".to_string()))
+    })?;
+
+    // Remove from AuthZ memberships (best effort)
+    if let Err(e) = state
+        .authz_provider
+        .remove_organisation_user(state.get_ref(), &auth.sub, &organisation, &entry.email)
+        .await
+    {
+        log::warn!(
+            "[DELETE SERVICE ACCOUNT] Failed to remove authz membership for '{}' (email '{}', org '{}', requested by '{}'): {}",
+            entry.name, mask_email(&entry.email), organisation, mask_email(&auth.sub), e
+        );
+    }
+
+    // Delete user from OIDC provider (best effort — invalidates all tokens)
+    if let Err(e) = state
+        .authn_provider
+        .delete_user(state.get_ref(), &entry.name)
+        .await
+    {
+        log::warn!(
+            "[DELETE SERVICE ACCOUNT] Failed to delete IdP user '{}' (email '{}', org '{}', requested by '{}'): {}",
+            entry.name, mask_email(&entry.email), organisation, mask_email(&auth.sub), e
+        );
+    }
+
+    // Delete from database
+    let pool = state.db_pool.clone();
+    run_blocking!({
+        let mut conn = pool.get()?;
+        diesel::delete(service_accounts_table.filter(sa_client_id.eq(&target_client_id)))
+            .execute(&mut conn)
+            .map_err(|e| {
+                log::error!("[DELETE SERVICE ACCOUNT] DB delete failed: {}", e);
+                ABError::InternalServerError(format!("Failed to delete service account: {}", e))
+            })?;
+        Ok(())
+    })?;
+
+    info!(
+        "Service account '{}' (id {}) deleted from org '{}' by '{}'",
+        entry.name,
+        target_client_id,
+        organisation,
+        mask_email(&auth.sub)
+    );
+
+    Ok(Json(DeleteServiceAccountResponse { success: true }))
+}
+
+#[authz(
+    resource = "service_account",
+    action = "create",
+    org_roles = ["owner", "admin"],
+    app_roles = []
+)]
+#[post("/{client_id}/rotate")]
+async fn rotate_service_account(
+    req: HttpRequest,
+    path: web::Path<uuid::Uuid>,
+    auth_response: ReqData<AuthResponse>,
+    state: web::Data<AppState>,
+) -> airborne_types::Result<Json<RotateServiceAccountResponse>> {
+    if !state.authn_provider.supports_service_accounts() {
+        return Err(ABError::BadRequest(
+            "Service accounts are not supported for configured AuthN provider".to_string(),
+        ));
+    }
+
+    let (organisation, _auth) = get_org_context(&req).await?;
+    let target_client_id = path.into_inner();
+
+    // Load service account from DB
+    let pool = state.db_pool.clone();
+    let org_filter = organisation.clone();
+    let entry = run_blocking!({
+        let mut conn = pool.get()?;
+        service_accounts_table
+            .filter(sa_client_id.eq(&target_client_id))
+            .filter(sa_org.eq(&org_filter))
+            .first::<ServiceAccountEntry>(&mut conn)
+            .map_err(|_| ABError::NotFound("Service account not found".to_string()))
+    })?;
+
+    // Rotate the identity in place: reset the password, revoke old sessions, and
+    // mint a fresh offline token. The same Keycloak user (and its `sub`) is kept.
+    let password = generate_random_password().await?;
+    let token = state
+        .authn_provider
+        .rotate_service_account_user(state.get_ref(), &entry.name, &password)
+        .await?;
+
+    // Re-key: new client_secret, re-encrypt the fresh refresh token under it, and
+    // persist. The previous client_secret can no longer decrypt the stored blob.
+    let client_secret = generate_random_key().await?;
+    let encrypted_refresh_token = encrypt_string(&token.refresh_token, &client_secret).await?;
+
+    let pool = state.db_pool.clone();
+    run_blocking!({
+        let mut conn = pool.get()?;
+        diesel::update(service_accounts_table.filter(sa_client_id.eq(&target_client_id)))
+            .set(sa_encrypted_refresh_token.eq(&encrypted_refresh_token))
+            .execute(&mut conn)
+            .map_err(|e| {
+                log::error!("[ROTATE SERVICE ACCOUNT] DB update failed: {}", e);
+                ABError::InternalServerError(format!("Failed to rotate service account: {}", e))
+            })?;
+        Ok(())
+    })?;
+
+    info!(
+        "Service account '{}' (id {}) credentials rotated in org '{}'",
+        entry.name, target_client_id, organisation
+    );
+
+    Ok(Json(RotateServiceAccountResponse {
+        client_id: target_client_id,
+        client_secret,
+    }))
+}

--- a/airborne_server/src/service_account/types.rs
+++ b/airborne_server/src/service_account/types.rs
@@ -1,0 +1,39 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+pub struct CreateServiceAccountRequest {
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    pub role: String,
+}
+
+#[derive(Serialize)]
+pub struct CreateServiceAccountResponse {
+    pub client_id: uuid::Uuid,
+    pub client_secret: String,
+    pub email: String,
+    pub name: String,
+}
+
+#[derive(Serialize)]
+pub struct ServiceAccountListEntry {
+    pub client_id: uuid::Uuid,
+    pub name: String,
+    pub email: String,
+    pub description: String,
+    pub created_by: String,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Serialize)]
+pub struct RotateServiceAccountResponse {
+    pub client_id: uuid::Uuid,
+    pub client_secret: String,
+}
+
+#[derive(Serialize)]
+pub struct DeleteServiceAccountResponse {
+    pub success: bool,
+}

--- a/airborne_server/src/service_account/utils.rs
+++ b/airborne_server/src/service_account/utils.rs
@@ -1,0 +1,80 @@
+// Copyright 2025 Juspay Technologies
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+
+use actix_web::{HttpMessage, HttpRequest};
+
+use crate::{
+    middleware::auth::{require_scope_name, AuthResponse},
+    types as airborne_types,
+    types::ABError,
+    utils::encryption::generate_random_key,
+};
+
+use super::{MAX_SERVICE_ACCOUNT_NAME_LENGTH, SERVICE_ACCOUNT_EMAIL_DOMAIN};
+
+/// Mask an email/subject for logging
+pub fn mask_email(value: &str) -> String {
+    let prefix: String = value.chars().take(3).collect();
+    format!("{}***", prefix)
+}
+
+pub fn validate_service_account_name(name: &str) -> airborne_types::Result<String> {
+    let trimmed = name.trim().to_ascii_lowercase();
+
+    if trimmed.is_empty() {
+        return Err(ABError::BadRequest(
+            "Service account name cannot be empty".to_string(),
+        ));
+    }
+
+    if trimmed.len() > MAX_SERVICE_ACCOUNT_NAME_LENGTH {
+        return Err(ABError::BadRequest(
+            "Service account name is too long".to_string(),
+        ));
+    }
+
+    if !trimmed
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(ABError::BadRequest(
+            "Service account name can only contain alphanumeric characters, hyphens, and underscores"
+                .to_string(),
+        ));
+    }
+
+    Ok(trimmed)
+}
+
+pub fn build_service_account_email(name: &str, organisation: &str) -> String {
+    let org_sanitized = organisation.trim().to_ascii_lowercase().replace(' ', "-");
+    format!(
+        "{}.{}@{}",
+        name, org_sanitized, SERVICE_ACCOUNT_EMAIL_DOMAIN
+    )
+}
+
+pub async fn generate_random_password() -> airborne_types::Result<String> {
+    generate_random_key().await
+}
+
+pub async fn get_org_context(req: &HttpRequest) -> airborne_types::Result<(String, AuthResponse)> {
+    let auth = req
+        .extensions()
+        .get::<AuthResponse>()
+        .cloned()
+        .ok_or_else(|| ABError::Unauthorized("Missing auth context".to_string()))?;
+
+    let org_name = require_scope_name(auth.organisation.clone(), "organisation")?;
+    Ok((org_name, auth))
+}

--- a/airborne_server/src/token.rs
+++ b/airborne_server/src/token.rs
@@ -9,10 +9,13 @@ use crate::{
     user::{exchange_code_for_token, types::OAuthLoginRequest, types::UserToken},
     utils::{
         db::{
-            models::UserCredentialsEntry,
-            schema::hyperotaserver::user_credentials::{
-                application as cred_app, client_id as uid, created_at, organisation as cred_org,
-                table as user_credentials_table, username,
+            models::{ServiceAccountEntry, UserCredentialsEntry},
+            schema::hyperotaserver::{
+                service_accounts::{client_id as sa_uid, table as service_accounts_table},
+                user_credentials::{
+                    application as cred_app, client_id as uid, created_at,
+                    organisation as cred_org, table as user_credentials_table, username,
+                },
             },
         },
         encryption::{decrypt_string, encrypt_string, generate_random_key},
@@ -287,36 +290,71 @@ async fn issue_token(
 
     let pool = state.db_pool.clone();
     let client_id = req.client_id;
-    let user = run_blocking!({
-        let mut conn = pool.get()?;
-        let user = user_credentials_table
-            .filter(uid.eq(&client_id))
-            .first::<UserCredentialsEntry>(&mut conn)
-            .map_err(|e| {
-                log::error!("[ISSUE TOKEN] Failed to load user credentials: {}", e);
-                ABError::Unauthorized("Invalid credentials".to_string())
-            })?;
-        Ok(user)
-    })?;
 
-    log::info!("[ISSUE TOKEN] User credentials loaded successfully");
-
-    let decrypted_refresh_token = decrypt_string(&user.password, &req.client_secret)
-        .await
-        .map_err(|e| {
-            log::error!("[ISSUE TOKEN] Failed to decrypt refresh token: {:?}", e);
-            ABError::Unauthorized("Invalid credentials".to_string())
+    // Try user_credentials first (PAT — needs decryption),
+    // then fall back to service_accounts (client_secret IS the refresh token).
+    let refresh_token = {
+        let pat_result = run_blocking!({
+            let mut conn = pool.get()?;
+            user_credentials_table
+                .filter(uid.eq(&client_id))
+                .first::<UserCredentialsEntry>(&mut conn)
+                .optional()
+                .map_err(|e| {
+                    log::error!("[ISSUE TOKEN] DB error: {}", e);
+                    ABError::InternalServerError("Database error".to_string())
+                })
         })?;
 
-    log::info!(
-        "[ISSUE TOKEN] Refresh token decrypted successfully, length: {}, first 10 chars: {}",
-        decrypted_refresh_token.len(),
-        &decrypted_refresh_token.chars().take(10).collect::<String>()
-    );
+        if let Some(user) = pat_result {
+            // PAT: decrypt the stored refresh token using client_secret as key
+            decrypt_string(&user.password, &req.client_secret)
+                .await
+                .map_err(|e| {
+                    log::error!("[ISSUE TOKEN] Failed to decrypt refresh token: {:?}", e);
+                    ABError::Unauthorized("Invalid credentials".to_string())
+                })?
+        } else {
+            // Service account: the offline refresh token is stored encrypted with
+            // the client_secret (same scheme as PATs above).
+            let pool2 = state.db_pool.clone();
+            let service_account = run_blocking!({
+                let mut conn = pool2.get()?;
+                service_accounts_table
+                    .filter(sa_uid.eq(&client_id))
+                    .first::<ServiceAccountEntry>(&mut conn)
+                    .optional()
+                    .map_err(|e| {
+                        log::error!("[ISSUE TOKEN] DB error: {}", e);
+                        ABError::InternalServerError("Database error".to_string())
+                    })
+            })?;
+
+            if let Some(service_account) = service_account {
+                decrypt_string(&service_account.encrypted_refresh_token, &req.client_secret)
+                    .await
+                    .map_err(|e| {
+                        log::error!(
+                            "[ISSUE TOKEN] Failed to decrypt service account refresh token: {:?}",
+                            e
+                        );
+                        ABError::Unauthorized("Invalid credentials".to_string())
+                    })?
+            } else {
+                log::error!(
+                    "[ISSUE TOKEN] No credentials found for client_id: {}",
+                    client_id
+                );
+                return Err(ABError::Unauthorized("Invalid credentials".to_string()));
+            }
+        }
+    };
+
+    log::info!("[ISSUE TOKEN] Credentials resolved successfully");
 
     let token = state
         .authn_provider
-        .refresh_access_token(state.get_ref(), &decrypted_refresh_token)
+        .refresh_access_token(state.get_ref(), &refresh_token)
         .await?;
     log::info!("[ISSUE TOKEN] Token issued successfully");
     Ok(Json(token))

--- a/airborne_server/src/utils/db/models.rs
+++ b/airborne_server/src/utils/db/models.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::utils::db::schema::hyperotaserver::{
     authz_memberships, authz_role_bindings, builds, cleanup_outbox, configs, files, packages,
-    packages_v2, release_views, releases, user_credentials, workspace_names,
+    packages_v2, release_views, releases, service_accounts, user_credentials, workspace_names,
 };
 use crate::utils::semver::SemVer;
 
@@ -236,4 +236,18 @@ pub struct NewAuthzRoleBindingEntry {
     pub role_key: String,
     pub resource: String,
     pub action: String,
+}
+
+#[derive(Queryable, Insertable, Debug, Selectable, Serialize)]
+#[diesel(table_name = service_accounts)]
+pub struct ServiceAccountEntry {
+    pub client_id: uuid::Uuid,
+    pub name: String,
+    pub email: String,
+    pub description: String,
+    pub organisation: String,
+    pub created_by: String,
+    pub created_at: DateTime<Utc>,
+    #[serde(skip_serializing)]
+    pub encrypted_refresh_token: String,
 }

--- a/airborne_server/src/utils/db/schema.rs
+++ b/airborne_server/src/utils/db/schema.rs
@@ -1,31 +1,6 @@
 // @generated automatically by Diesel CLI.
 
 pub mod hyperotaserver {
-    pub mod sql_types {
-        #[derive(diesel::query_builder::QueryId, Clone, diesel::sql_types::SqlType)]
-        #[diesel(postgres_type(name = "invite_role", schema = "hyperotaserver"))]
-        pub struct InviteRole;
-
-        #[derive(diesel::query_builder::QueryId, Clone, diesel::sql_types::SqlType)]
-        #[diesel(postgres_type(name = "invite_status", schema = "hyperotaserver"))]
-        pub struct InviteStatus;
-    }
-
-    diesel::table! {
-        hyperotaserver.builds (id) {
-            id -> Uuid,
-            build_version -> Text,
-            organisation -> Text,
-            application -> Text,
-            release_id -> Text,
-            created_at -> Timestamptz,
-            major_version -> Int4,
-            minor_version -> Int4,
-            patch_version -> Int4,
-            status -> Text,
-        }
-    }
-
     diesel::table! {
         hyperotaserver.authz_memberships (subject, scope, organisation, application) {
             subject -> Text,
@@ -45,6 +20,21 @@ pub mod hyperotaserver {
             resource -> Text,
             action -> Text,
             created_at -> Timestamptz,
+        }
+    }
+
+    diesel::table! {
+        hyperotaserver.builds (id) {
+            id -> Uuid,
+            build_version -> Text,
+            organisation -> Text,
+            application -> Text,
+            release_id -> Text,
+            created_at -> Timestamptz,
+            major_version -> Int4,
+            minor_version -> Int4,
+            patch_version -> Int4,
+            status -> Text,
         }
     }
 
@@ -87,23 +77,6 @@ pub mod hyperotaserver {
             size -> Int8,
             checksum -> Text,
             metadata -> Jsonb,
-            created_at -> Timestamptz,
-        }
-    }
-
-    diesel::table! {
-        use diesel::sql_types::*;
-        use super::sql_types::InviteRole;
-        use super::sql_types::InviteStatus;
-
-        hyperotaserver.organisation_invites (id) {
-            id -> Uuid,
-            org_id -> Text,
-            applications -> Jsonb,
-            email -> Text,
-            role -> InviteRole,
-            token -> Text,
-            status -> InviteStatus,
             created_at -> Timestamptz,
         }
     }
@@ -160,6 +133,19 @@ pub mod hyperotaserver {
     }
 
     diesel::table! {
+        hyperotaserver.service_accounts (client_id) {
+            client_id -> Uuid,
+            name -> Text,
+            email -> Text,
+            description -> Text,
+            organisation -> Text,
+            created_by -> Text,
+            created_at -> Timestamptz,
+            encrypted_refresh_token -> Text,
+        }
+    }
+
+    diesel::table! {
         hyperotaserver.user_credentials (client_id) {
             client_id -> Uuid,
             username -> Text,
@@ -182,15 +168,15 @@ pub mod hyperotaserver {
     diesel::allow_tables_to_appear_in_same_query!(
         authz_memberships,
         authz_role_bindings,
-        cleanup_outbox,
         builds,
+        cleanup_outbox,
         configs,
         files,
-        organisation_invites,
         packages,
         packages_v2,
         release_views,
         releases,
+        service_accounts,
         user_credentials,
         workspace_names,
     );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added organisation service account management in the dashboard, including creating, listing, deleting, and rotating credentials.
  * Service account credentials can now be copied or downloaded as JSON.
  * Token handling now supports service accounts alongside regular user credentials.

* **Bug Fixes**
  * Regular user management now excludes service accounts from the standard user list.
  * Added validation to prevent service-account addresses from being added as normal organisation users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->