### PR TITLE
feat: rich download after timeout event in ios

### DIFF
--- a/airborne_sdk_iOS/hyper-ota/Airborne/AirborneObjC/ApplicationManager/Tracker/AJPApplicationTracker.m
+++ b/airborne_sdk_iOS/hyper-ota/Airborne/AirborneObjC/ApplicationManager/Tracker/AJPApplicationTracker.m
@@ -5,11 +5,18 @@
 //  Copyright © Juspay Technologies. All rights reserved.
 //
 
+#if SWIFT_PACKAGE
+// Must precede AJPApplicationTracker.h: that header declares <AJPLoggerDelegate> against a bare
+// forward declaration. Without the real definition in scope, the class records no conformance and
+// `[logger conformsToProtocol:@protocol(AJPLoggerDelegate)]` below always answers NO, silently
+// dropping every event.
+@import AirborneSwiftCore;
+@import AirborneSwiftModel;
+#endif
+
 #import "AJPApplicationTracker.h"
 #import "AJPHelpers.h"
-#if SWIFT_PACKAGE
-@import AirborneSwiftModel;
-#else
+#if !SWIFT_PACKAGE
 #import <Airborne/Airborne-Swift.h>
 #endif
 

--- a/airborne_sdk_iOS/hyper-ota/Airborne/AirborneSwift/AJPApplicationManager.swift
+++ b/airborne_sdk_iOS/hyper-ota/Airborne/AirborneSwift/AJPApplicationManager.swift
@@ -1231,6 +1231,10 @@ public typealias AJPReleaseConfigCompletionHandler = (AJPApplicationManifest?, E
                 map["failed_downloads"] = Array(failedDownloads)
                 map["all_successful"] = failedDownloads.isEmpty
                 map["time_taken"] = NSNumber(value: (Date().timeIntervalSince1970 * 1000) - startTime)
+                // The package is on disk but was not installed this boot; it is staged for the next
+                // Airborne init. Integrators prompt for a reload on this event.
+                map["package_version"] = newManifest.version
+                map["current_package_version"] = currentManifest.version
                 self.tracker.trackInfo("downloads_completed_after_timeout", value: map)
                 
                 resultDownloadFailed = false

--- a/airborne_sdk_iOS/hyper-ota/Airborne/AirborneSwift/AJPApplicationManager.swift
+++ b/airborne_sdk_iOS/hyper-ota/Airborne/AirborneSwift/AJPApplicationManager.swift
@@ -886,6 +886,20 @@ public typealias AJPReleaseConfigCompletionHandler = (AJPApplicationManifest?, E
         }
     }
     
+    /**
+     * Raised alongside the `downloads_completed_after_timeout` event: the package finished
+     * downloading after the boot timeout elapsed, so it is staged and installs on the next Airborne
+     * initialization. The app is still running `oldVersion` — prompt for a reload to apply it.
+     *
+     * Not raised when the package installs within the boot timeout; there is nothing to reload for.
+     */
+    private func notifyPackageDownloaded(oldVersion: String, newVersion: String) {
+        self.delegate?.onPackageDownloaded?(
+            oldVersion: oldVersion,
+            newVersion: newVersion
+        )
+    }
+
     private func tryDownloadingUpdate() {
         guard let downloadedManifest = self.downloadedApplicationManifest else { return }
         
@@ -901,8 +915,12 @@ public typealias AJPReleaseConfigCompletionHandler = (AJPApplicationManifest?, E
                     self.downloadedLazy = downloadedManifest.package.lazy
                 }
                 
+                // Captured before the download call, which installs the new package (and so
+                // overwrites self.package) when the boot timeout has not elapsed.
+                let currentPackageVersion = self.package.version
+
                 let (downloadFailed, timedOut) = await self.downloadImportantPackagesWithNewManifest(downloadedManifest.package, currentManifest: self.package)
-                
+
                 if !downloadFailed { // Important packages downloaded successfully/No updates.
                     self.didFinishImportantPackageWithLazyDownloadComplete(timedOut)
                     
@@ -1236,6 +1254,11 @@ public typealias AJPReleaseConfigCompletionHandler = (AJPApplicationManifest?, E
                 map["package_version"] = newManifest.version
                 map["current_package_version"] = currentManifest.version
                 self.tracker.trackInfo("downloads_completed_after_timeout", value: map)
+
+                self.notifyPackageDownloaded(
+                    oldVersion: currentManifest.version,
+                    newVersion: newManifest.version
+                )
                 
                 resultDownloadFailed = false
                 resultTimedOut = true

--- a/airborne_sdk_iOS/hyper-ota/Airborne/AirborneSwift/AJPApplicationManagerDelegate.swift
+++ b/airborne_sdk_iOS/hyper-ota/Airborne/AirborneSwift/AJPApplicationManagerDelegate.swift
@@ -119,4 +119,18 @@ import AirborneSwiftCore
      *       AJPRemoteFileUtil implementation.
      */
     @objc optional func getRemoteFileUtil() -> AJPRemoteFileUtil
+
+    /**
+     * Called when a new package's important splits have finished downloading.
+     *
+     * Raised regardless of whether the boot timeout elapsed: when it did, the package is staged
+     * and installs on the next Airborne initialization; when it did not, it is installed and
+     * applied on this run.
+     *
+     * @param oldVersion The package version the app is currently running.
+     * @param newVersion The package version that was just downloaded.
+     *
+     * @note Called on a background queue. Dispatch UI updates to the main queue.
+     */
+    @objc optional func onPackageDownloaded(oldVersion: String, newVersion: String)
 }

--- a/airborne_sdk_iOS/hyper-ota/Airborne/AirborneSwift/Airborne.swift
+++ b/airborne_sdk_iOS/hyper-ota/Airborne/AirborneSwift/Airborne.swift
@@ -105,6 +105,21 @@ import AirborneSwiftModel
      * @note Use this for logging, analytics, debugging, and monitoring OTA performance.
      */
     @objc optional func onEvent(level: String, label: String, key: String, value: [String: Any], category: String, subcategory: String) -> Void
+
+    /**
+     * Called when a new package's important splits have finished downloading.
+     *
+     * Raised regardless of whether the boot timeout elapsed:
+     * - Timed out: the package is staged and will be installed on the next Airborne
+     *   initialization. Prompt the user to reload to apply it now.
+     * - Did not time out: the package was installed and is already in use on this run.
+     *
+     * @param oldVersion The package version the app is currently running.
+     * @param newVersion The package version that was just downloaded.
+     *
+     * @note Called on a background queue. Dispatch UI updates to the main queue if needed.
+     */
+    @objc optional func onPackageDownloaded(oldVersion: String, newVersion: String) -> Void
     
     /**
      * Called when an individual lazy package download completes (either successfully or with failure).
@@ -363,6 +378,16 @@ extension AirborneServices: AJPApplicationManagerDelegate {
      */
     public func getReleaseConfigHeaders() -> [String : String] {
         self.dimensions
+    }
+
+    /**
+     * Forwards the package-downloaded callback from the application manager to the delegate.
+     */
+    public func onPackageDownloaded(oldVersion: String, newVersion: String) {
+        self.delegate?.onPackageDownloaded?(
+            oldVersion: oldVersion,
+            newVersion: newVersion
+        )
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logger event tracking to prevent relevant events from being silently omitted.
  * Enhanced timeout event details with the newly downloaded and currently installed package versions.
  * Clarified that staged packages are applied during the next initialization rather than the current boot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->