### PR TITLE
chore: docs for bare airborne integration

### DIFF
--- a/airborne_docs/docs/bare-integration/expo.md
+++ b/airborne_docs/docs/bare-integration/expo.md
@@ -1,0 +1,97 @@
+---
+title: Expo (bare)
+description: Adapt the bare Airborne integration for an Expo app — the Airborne wiring is identical to the plain React Native flow, with Expo's app-delegate and host wrappers preserved.
+---
+
+The bare Airborne integration for **Expo** is the same as the [plain React Native flow](/docs/bare-integration/react-native): the same native dependencies (`in.juspay:airborne` `2.2.8-rc.25` on Android, the `Airborne` pod `0.42.0` on iOS), the same `HyperOTAServices` / `AirborneServices` wiring, and the same [reload-after-download](/docs/bare-integration/reload-after-download) capability. Only a handful of **Expo-specific touchpoints** differ.
+
+:::note[Prerequisites]
+- Run `npx expo prebuild` so the native `android/` and `ios/` projects exist — the bare flow edits native code directly.
+- Read [React Native (bare)](/docs/bare-integration/react-native) first. This page only lists what changes for Expo; the Airborne wiring itself is unchanged.
+:::
+
+:::caution[This is the advanced flow]
+For most Expo apps, the [React Native SDK Expo track](/docs/react-native-sdk/expo/getting-started) is simpler. Use the bare flow only when you need the low-level control described in the [overview](/docs/bare-integration/overview).
+:::
+
+## What is identical
+
+Follow these steps from [React Native (bare)](/docs/bare-integration/react-native) unchanged:
+
+- **Android** — Step 1 (add the Maven repository) and Step 2 (add the `in.juspay:airborne:2.2.8-rc.25` dependency).
+- **iOS** — Step 4 (add `pod 'Airborne', '0.42.0'`, then `pod install`).
+- The Airborne initialization itself: creating `HyperOTAServices` / `AirborneServices`, resolving the bundle from `getIndexBundlePath()`, and the `onPackageDownloaded` handling.
+
+## Android — Expo touchpoints
+
+The Airborne wiring in `MainApplication` (creating `HyperOTAServices`, `createApplicationManager`, `loadApplication`, and resolving `getIndexBundlePath()`) is exactly as in the plain React Native flow. Preserve these Expo specifics on top of it:
+
+- **Keep Expo's lifecycle dispatch.** Call `ApplicationLifecycleDispatcher.onApplicationCreate(this)` at the end of `onCreate()`, and set the New Architecture release level, just as Expo's generated `MainApplication` does:
+
+  ```kotlin
+  override fun onCreate() {
+      super.onCreate()
+      DefaultNewArchitectureEntryPoint.releaseLevel = try {
+          ReleaseLevel.valueOf(BuildConfig.REACT_NATIVE_RELEASE_LEVEL.uppercase())
+      } catch (e: IllegalArgumentException) {
+          ReleaseLevel.STABLE
+      }
+      startAirborne()                                    // your Airborne init (unchanged)
+      loadReactNative(this)
+      ApplicationLifecycleDispatcher.onApplicationCreate(this)  // keep Expo's dispatch
+  }
+  ```
+
+- **Use Expo's JS entry.** Where the plain flow uses `index` as the JS main module, Expo resolves its entry through the virtual metro module `.expo/.virtual-metro-entry`. Keep that value wherever your host declares the JS main module name — using `index` breaks Expo's bundling.
+- **Keep Expo's host / activity wrappers.** If your generated project wraps the host in `ReactNativeHostWrapper` and the activity delegate in `ReactActivityDelegateWrapper`, keep those wrappers so Expo modules keep working. The Airborne bundle path is still supplied through the resolved bundle path (`getIndexBundlePath()`) — see the wrapper mechanics in the [standard Expo Android setup](/docs/react-native-sdk/expo/android-setup).
+
+## iOS — Expo touchpoints
+
+Your Expo app delegate extends **`ExpoAppDelegate`**. Take the `AppDelegate` from [React Native (bare) — Step 5](/docs/bare-integration/react-native) and apply these three changes:
+
+1. **Extend `ExpoAppDelegate`** (which already declares `reactNativeDelegate` / `reactNativeFactory`), and make `application(_:didFinishLaunchingWithOptions:)` a `public override` that calls `super`. Expo generates **three** `application` functions — update **only** `didFinishLaunchingWithOptions`; leave the URL/universal-link ones untouched.
+
+   ```swift
+   @main
+   public class AppDelegate: ExpoAppDelegate, AirborneDelegate {
+
+       var launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+       private var airborne: AirborneServices?
+       private var reactStarted = false
+
+       public override func application(
+           _ application: UIApplication,
+           didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+       ) -> Bool {
+           self.launchOptions = launchOptions
+           window = UIWindow(frame: UIScreen.main.bounds)
+           airborne = AirborneServices(releaseConfigURL: RELEASE_CONFIG_URL, delegate: self)
+           return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+       }
+       // …AirborneDelegate methods unchanged from the RN bare page…
+   }
+   ```
+
+2. **Bind the factory and use module name `"main"`.** In `bootReactNative`, call `bindReactNativeFactory(factory)` (provided by `ExpoAppDelegate`) before starting, and pass `withModuleName: "main"` — Expo registers its root component under `main`, not your app name:
+
+   ```swift
+   let factory = RCTReactNativeFactory(delegate: delegate)
+   reactNativeDelegate = delegate
+   reactNativeFactory = factory
+   bindReactNativeFactory(factory)                        // Expo-specific
+
+   factory.startReactNative(
+       withModuleName: "main",                            // Expo registers under "main"
+       in: window,
+       launchOptions: launchOptions
+   )
+   ```
+
+3. **Keep the `ReactNativeDelegate`** exactly as in the plain flow — it still returns the Airborne-resolved bundle URL from `bundleURL()`.
+
+Everything else — the `AirborneDelegate` methods, the `reactStarted` guard, and the `onPackageDownloaded` reload flow — is identical to the plain React Native flow.
+
+## Next
+
+- **[Reload after a post-timeout update](/docs/bare-integration/reload-after-download)** — wire `onPackageDownloaded` into a reload prompt (works the same on Expo).
+- **[Create & target a release](/docs/guides/create-and-target-a-release)** — release creation is unchanged from the dashboard.

--- a/airborne_docs/docs/bare-integration/overview.md
+++ b/airborne_docs/docs/bare-integration/overview.md
@@ -1,0 +1,53 @@
+---
+title: Bare Airborne (Advanced)
+description: Integrate the native Airborne OTA SDKs directly into a React Native or Expo app — without the airborne-react-native plugin — for deep control over the OTA lifecycle.
+---
+
+**Bare Airborne** wires the native Airborne OTA SDKs — `in.juspay:airborne` on Android and the `Airborne` CocoaPod on iOS — **directly** into a React Native or Expo app, **without** the [`airborne-react-native`](/docs/react-native-sdk/overview) plugin. Instead of letting the plugin manage the bundle and boot for you, you write the native boot code yourself: you decide when React Native starts, which bundle it boots from, and how the app reacts when a new package finishes downloading.
+
+:::caution[Prefer the React Native SDK for most apps]
+This is an **advanced** flow for teams that need low-level control over the OTA lifecycle. It means owning more native code (`MainApplication`/`AppDelegate`) and keeping it in sync with React Native upgrades.
+
+For a typical app, use the **[React Native SDK](/docs/react-native-sdk/overview)** instead — it handles the native wiring for you and is far simpler to set up. Only reach for the bare flow when you have a concrete reason to.
+:::
+
+## When to use the bare flow
+
+Choose the bare integration when you need something the plugin does not currently expose — most commonly:
+
+- **Reacting to `onPackageDownloaded`.** The native SDKs raise this callback when a package finishes downloading *after* the boot timeout (so it is staged rather than applied on this run). The bare flow lets you catch it and, for example, show a **"Reload now"** prompt so users get the update without waiting for a natural app restart. See [Reload after a post-timeout update](/docs/bare-integration/reload-after-download).
+- **Full control of the boot and reload sequence** — exactly when and how React Native starts, and how you swap the bundle and reload JS when an update is applied.
+
+If you don't need any of this, the [React Native SDK](/docs/react-native-sdk/overview) does the same OTA delivery with much less code.
+
+## What stays the same
+
+The bare flow only changes the **SDK integration** in your app. Everything on the Airborne side is unchanged:
+
+- **Release creation is identical.** You still build packages and create releases, cohorts, and dimensions from the **Airborne dashboard** exactly as with the plugin. See [Create & target a release](/docs/guides/create-and-target-a-release) and the [Releases](/docs/dashboard/releases) reference.
+- **The core concepts are the same** — release config, package, namespace, resources, and the boot / release-config timeouts. See [Download & boot flow](/docs/concepts/download-and-boot-flow).
+
+## What differs
+
+- You add the **native Airborne SDK** as a direct dependency (Gradle on Android, CocoaPods on iOS) instead of the `airborne-react-native` npm package.
+- You write the **boot integration** yourself — initialize Airborne before React Native, resolve the bundle path from the SDK, and hand it to React Native.
+- You get direct access to the native callbacks, including **`onPackageDownloaded`**.
+
+## Versions
+
+Use these published versions of the native SDKs:
+
+| Platform | Dependency | Version |
+| --- | --- | --- |
+| Android | `in.juspay:airborne` (Gradle) | `2.2.8-rc.25` |
+| iOS | `Airborne` (CocoaPods) | `0.42.0` |
+
+:::note[The Hyper SDK Maven repository is still required]
+The Android SDK resolves from the Hyper SDK Maven repository **`https://maven.juspay.in/jp-build-packages/hyper-sdk/`** — the same repository the plugin uses. Keep it in your Gradle configuration (see [React Native (bare)](/docs/bare-integration/react-native)).
+:::
+
+## Next
+
+- **[React Native (bare)](/docs/bare-integration/react-native)** — the full Android + iOS integration for a plain React Native app.
+- **[Expo (bare)](/docs/bare-integration/expo)** — the same integration, adapted for Expo's app-delegate and host wrappers.
+- **[Reload after a post-timeout update](/docs/bare-integration/reload-after-download)** — the `onPackageDownloaded` use case and the `boot_timeout: 0` "always prompt" configuration.

--- a/airborne_docs/docs/bare-integration/react-native.md
+++ b/airborne_docs/docs/bare-integration/react-native.md
@@ -1,0 +1,301 @@
+---
+title: React Native (bare)
+description: Integrate the native Airborne SDKs directly into a plain React Native app — add the Gradle/CocoaPods dependencies and boot React Native from the OTA bundle in MainApplication and AppDelegate.
+---
+
+This page covers the full **bare** integration for a plain React Native app: adding the native Airborne dependency, then writing the boot code that initializes Airborne, resolves the OTA bundle, and hands it to React Native. There is **no `airborne-react-native` npm package** in this flow — you talk to the native SDK directly.
+
+:::caution[This is the advanced flow]
+For most apps the [React Native SDK](/docs/react-native-sdk/integration/getting-started) is simpler. Read the [Bare Airborne overview](/docs/bare-integration/overview) first to decide whether you need this.
+:::
+
+:::note[Prerequisites]
+- A working plain React Native app (New Architecture). If you use Expo, follow [Expo (bare)](/docs/bare-integration/expo) instead.
+- A namespace/application created on the Airborne dashboard and a release URL of the form `https://airborne.juspay.in/release/<organisation>/<application/namespace-name>`.
+- A **bundled `release_config.json`** and JS bundle shipped in the app binary for the first-run / offline fallback, exactly as for the plugin flow — see [Bundling the release config](/docs/react-native-sdk/integration/bundling-release-config).
+:::
+
+Throughout, replace `<organisation>`, `<application/namespace-name>`, and `YourAppName` (your registered module name) with your own values.
+
+## Android
+
+### Step 1: Add the Maven repository
+
+The native Android SDK is distributed from the Hyper SDK Maven repository. Add it under `allprojects { repositories { ... } }` in `android/build.gradle`:
+
+```groovy
+allprojects {
+    repositories {
+        maven { url "https://maven.juspay.in/jp-build-packages/hyper-sdk/" }
+    }
+}
+```
+
+If your project uses the newer Gradle settings model, add it to `android/settings.gradle` under `dependencyResolutionManagement { repositories { ... } }` instead.
+
+:::caution
+Declare the repository in exactly one place. If `dependencyResolutionManagement` uses `RepositoriesMode.FAIL_ON_PROJECT_REPOS`, adding repositories in `build.gradle` will fail the build — put the Maven URL in `settings.gradle`.
+:::
+
+### Step 2: Add the dependency
+
+In `android/app/build.gradle`, add the native Airborne SDK:
+
+```groovy
+dependencies {
+    implementation("in.juspay:airborne:2.2.8-rc.25")
+}
+```
+
+This pulls in the native OTA engine (and its `in.juspay:hyperutil` transitive dependency) from the Maven repository above. You do **not** add `airborne-react-native`.
+
+### Step 3: Boot React Native from the OTA bundle
+
+In the bare flow you build the `ReactHost` yourself and give it the bundle path Airborne resolved. The key pieces in `MainApplication.kt`:
+
+- Create `HyperOTAServices` with your namespace, release URL, a `TrackerCallback`, and the `onBootComplete` / `onPackageDownloaded` callbacks.
+- Call `createApplicationManager(...)` then `loadApplication(...)` to start the update.
+- In `reactHost`, resolve the bundle path with `appManager.getIndexBundlePath()` — this **blocks until Airborne has a bundle ready**, which is how boot waits for the OTA copy. Fall back to the APK's bundled asset when nothing is staged yet.
+
+```kotlin
+package com.yourapp
+
+import android.app.Application
+import android.util.Log
+import com.facebook.react.PackageList
+import com.facebook.react.ReactApplication
+import com.facebook.react.ReactHost
+import com.facebook.react.ReactNativeApplicationEntryPoint.loadReactNative
+import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
+import `in`.juspay.airborne.HyperOTAServices
+import `in`.juspay.airborne.TrackerCallback
+import `in`.juspay.airborne.ota.ApplicationManager
+import org.json.JSONObject
+
+private const val TAG = "Airborne"
+private const val NAMESPACE = "<application/namespace-name>"
+private const val RELEASE_CONFIG_URL =
+    "https://airborne.juspay.in/release/<organisation>/<application/namespace-name>"
+
+class MainApplication : Application(), ReactApplication {
+
+    private lateinit var appManager: ApplicationManager
+
+    override val reactHost: ReactHost by lazy {
+        val bundlePath = resolveBundlePath()
+        Log.i(TAG, "handing bundle to React Native: $bundlePath")
+        getDefaultReactHost(
+            context = applicationContext,
+            packageList = PackageList(this).packages,
+            jsBundleFilePath = bundlePath,
+            useDevSupport = false,
+        )
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        startAirborne()
+        loadReactNative(this)
+    }
+
+    private fun startAirborne() {
+        val tracker = object : TrackerCallback() {
+            override fun track(
+                category: String, subCategory: String, level: String,
+                label: String, key: String, value: JSONObject,
+            ) {
+                Log.d(TAG, "track [$level] $label | $key | $value")
+            }
+
+            override fun trackException(
+                category: String, subCategory: String,
+                label: String, description: String, e: Throwable,
+            ) {
+                Log.e(TAG, "trackException $label | $description", e)
+            }
+        }
+
+        val services = HyperOTAServices(
+            applicationContext,
+            NAMESPACE,
+            "",                       // appVersion — optional, used for targeting
+            RELEASE_CONFIG_URL,
+            tracker,
+            onBootComplete = { indexPath -> Log.i(TAG, "bootComplete indexPath='$indexPath'") },
+            // Raised when a package finishes downloading after the boot timeout (staged, not yet
+            // applied). See "Reload after a post-timeout update" to turn this into a reload prompt.
+            onPackageDownloaded = { old, new -> Log.i(TAG, "onPackageDownloaded old=$old new=$new") },
+        )
+
+        appManager = services.createApplicationManager(hashMapOf())
+        appManager.loadApplication(NAMESPACE, null)
+    }
+
+    private fun resolveBundlePath(): String {
+        // Blocks until Airborne has resolved a bundle. Returns the staged OTA bundle if present…
+        val staged = appManager.getIndexBundlePath()
+        if (staged.isNotEmpty()) {
+            Log.i(TAG, "booting from OTA bundle on disk")
+            return staged
+        }
+        // …otherwise fall back to the bundle shipped in the APK.
+        val bundled = appManager.getBundledIndexPath().ifEmpty { "index.android.bundle" }
+        Log.i(TAG, "no OTA bundle staged, booting from APK assets")
+        return "assets://$bundled"
+    }
+}
+```
+
+:::caution[Namespace must match]
+The `NAMESPACE` you pass to `HyperOTAServices` and `loadApplication` must match the `<application/namespace-name>` segment of your release URL **and** the folder holding your bundled `release_config.json`. A mismatch means the SDK cannot find the right bundle.
+:::
+
+`MainActivity` needs **no Airborne-specific changes** — a standard `ReactActivity` with `DefaultReactActivityDelegate` is fine, because the bundle path is supplied through the `ReactHost` above, not through the activity delegate.
+
+## iOS
+
+### Step 4: Add the pod
+
+Add the native `Airborne` pod to your `ios/Podfile` target:
+
+```ruby
+target 'YourAppName' do
+  # …existing React Native config…
+
+  pod 'Airborne', '0.42.0'
+end
+```
+
+Then install:
+
+```bash
+cd ios && pod install
+```
+
+:::note[Native pod, not AirborneReact]
+The bare flow uses the native **`Airborne`** pod. This is different from the `AirborneReact` pod the plugin auto-links — do not add both.
+:::
+
+### Step 5: Boot React Native from the OTA bundle
+
+In `AppDelegate.swift`, initialize `AirborneServices` early (it starts fetching immediately), conform to `AirborneDelegate`, and start React Native from the `startApp(indexBundleURL:)` callback — once Airborne hands you the resolved bundle. React Native is **not** started in `didFinishLaunchingWithOptions`.
+
+```swift
+import UIKit
+import React
+import React_RCTAppDelegate
+import ReactAppDependencyProvider
+import Airborne
+
+private let NAMESPACE = "<application/namespace-name>"
+private let RELEASE_CONFIG_URL =
+    "https://airborne.juspay.in/release/<organisation>/<application/namespace-name>"
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate, AirborneDelegate {
+
+    var window: UIWindow?
+    var reactNativeDelegate: ReactNativeDelegate?
+    var reactNativeFactory: RCTReactNativeFactory?
+
+    private var airborne: AirborneServices?
+    private var launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    private var reactStarted = false
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        self.launchOptions = launchOptions
+        window = UIWindow(frame: UIScreen.main.bounds)
+
+        // Airborne resolves the bundle (installing any package staged by a previous run) before RN
+        // boots. startApp(indexBundleURL:) fires once boot completes or the boot timeout elapses.
+        airborne = AirborneServices(releaseConfigURL: RELEASE_CONFIG_URL, delegate: self)
+        return true
+    }
+
+    // MARK: - AirborneDelegate
+
+    func namespace() -> String { NAMESPACE }
+
+    func indexBundleName() -> String { "main.jsbundle" }
+
+    func dimensions() -> [String: String] { [:] }
+
+    func startApp(indexBundleURL: URL?) {
+        DispatchQueue.main.async { [weak self] in
+            self?.bootReactNative(bundleURL: indexBundleURL)
+        }
+    }
+
+    func onEvent(
+        level: String, label: String, key: String,
+        value: [String: Any], category: String, subcategory: String
+    ) {
+        NSLog("[Airborne] [%@] %@ | %@", level, label, key)
+    }
+
+    // Raised when a package finishes downloading after the boot timeout (staged, not yet applied).
+    // See "Reload after a post-timeout update" to turn this into a reload prompt.
+    func onPackageDownloaded(oldVersion: String, newVersion: String) {
+        NSLog("[Airborne] onPackageDownloaded old=%@ new=%@", oldVersion, newVersion)
+    }
+
+    // MARK: - React Native boot
+
+    private func bootReactNative(bundleURL: URL?) {
+        guard !reactStarted else {
+            // Already running: a staged package was installed, so swap the bundle and reload JS.
+            reactNativeDelegate?.airborneBundleURL = bundleURL
+            RCTTriggerReloadCommandListeners("Airborne OTA update applied")
+            return
+        }
+        reactStarted = true
+
+        let delegate = ReactNativeDelegate()
+        delegate.airborneBundleURL = bundleURL
+        delegate.dependencyProvider = RCTAppDependencyProvider()
+        let factory = RCTReactNativeFactory(delegate: delegate)
+
+        reactNativeDelegate = delegate
+        reactNativeFactory = factory
+
+        factory.startReactNative(
+            withModuleName: "YourAppName",
+            in: window,
+            launchOptions: launchOptions
+        )
+    }
+}
+
+class ReactNativeDelegate: RCTDefaultReactNativeFactoryDelegate {
+    var airborneBundleURL: URL?
+
+    override func sourceURL(for bridge: RCTBridge) -> URL? {
+        self.bundleURL()
+    }
+
+    override func bundleURL() -> URL? {
+        // Always the path Airborne resolved — never Metro, never a hardcoded main.jsbundle.
+        airborneBundleURL ?? Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+    }
+}
+```
+
+The `reactStarted` guard in `bootReactNative` means a **second** `startApp` call (which happens when you re-initialize Airborne to apply a staged update) reloads JS onto the new bundle instead of starting a second React Native instance. That path is used by [Reload after a post-timeout update](/docs/bare-integration/reload-after-download).
+
+:::caution[Namespace must match]
+`namespace()` must match the `<application/namespace-name>` segment of your release URL and your bundled config location.
+:::
+
+## Verify
+
+1. Ship a build with a bundled `release_config.json` and note the marker text visible on screen.
+2. From the dashboard, create a package with a changed marker and [create a release](/docs/guides/create-and-target-a-release) targeting your app.
+3. Relaunch the app. On a cold start where the download finishes within the boot timeout, the app boots straight onto the new bundle. If it finishes *after* the timeout, it is staged — watch for the `onPackageDownloaded` log, and see the next page to prompt a reload.
+
+## Next
+
+- **[Reload after a post-timeout update](/docs/bare-integration/reload-after-download)** — the reason to use the bare flow: turn `onPackageDownloaded` into a "Reload now" prompt.
+- **[Expo (bare)](/docs/bare-integration/expo)** — if your app is built with Expo.

--- a/airborne_docs/docs/bare-integration/reload-after-download.md
+++ b/airborne_docs/docs/bare-integration/reload-after-download.md
@@ -1,0 +1,173 @@
+---
+title: Reload after a post-timeout update
+description: Use the onPackageDownloaded callback in the bare Airborne flow to prompt users to reload when an update lands after the boot timeout, plus the boot_timeout 0 "always prompt" configuration.
+---
+
+This is the payoff of the [bare Airborne flow](/docs/bare-integration/overview): the native SDKs raise **`onPackageDownloaded`** when a new package finishes downloading, and you can use it to offer users a **"Reload now"** prompt so they get the update immediately — instead of waiting for the next natural app restart.
+
+:::note[Prerequisites]
+Complete the [React Native (bare)](/docs/bare-integration/react-native) or [Expo (bare)](/docs/bare-integration/expo) integration first. This page extends the `onPackageDownloaded` stub left in those pages.
+:::
+
+## When `onPackageDownloaded` fires
+
+Recall the [download & boot flow](/docs/concepts/download-and-boot-flow): on launch the SDK races the package's important files against the **boot timeout**.
+
+- **Downloaded within the boot timeout** — the package is applied on this run and React Native boots straight onto it. `onPackageDownloaded` is **not** the interesting case here; the user already has the update.
+- **Downloaded *after* the boot timeout** — boot already happened on the previous package, so the freshly downloaded package is **staged**: written to disk and applied on the **next** Airborne initialization. `onPackageDownloaded(oldVersion, newVersion)` fires to tell you a newer package is ready but not yet running.
+
+That second case is the one worth handling. Without any UX, the staged update only takes effect the next time the user cold-starts the app. By reacting to `onPackageDownloaded`, you can apply it now.
+
+:::info[The callback delivers versions, not files]
+`onPackageDownloaded(oldVersion, newVersion)` gives you the package version the app is currently running (`oldVersion`) and the one that was just staged (`newVersion`). It is delivered on a **background thread** on both platforms — dispatch any UI work to the main thread. Ignore it when `newVersion` is empty or equal to `oldVersion`.
+:::
+
+## Android — prompt and restart
+
+Applying a staged package on Android means starting a fresh process: Airborne installs the staged files during its init on the next process start, before React Native loads them. `Activity.recreate()` is not enough — it does not re-run `Application.onCreate`.
+
+Extend the `MainApplication` from [React Native (bare)](/docs/bare-integration/react-native): track the foreground activity (the download can land before any activity resumes), fill in `onPackageDownloaded`, and add the prompt + restart.
+
+```kotlin
+import android.app.Activity
+import android.app.AlertDialog
+import android.content.Intent
+import android.os.Bundle
+import java.util.concurrent.atomic.AtomicReference
+
+// Add to MainApplication:
+
+@Volatile private var currentActivity: Activity? = null
+
+/** A staged version awaiting a prompt; the download can finish before any Activity resumes. */
+private val pendingPrompt = AtomicReference<String?>(null)
+
+/** Call this from onCreate(), before loadReactNative(this). */
+private fun trackForegroundActivity() {
+    registerActivityLifecycleCallbacks(object : ActivityLifecycleCallbacks {
+        override fun onActivityResumed(activity: Activity) {
+            currentActivity = activity
+            showPendingPrompt(activity)   // drain a prompt that arrived before this resume
+        }
+        override fun onActivityPaused(activity: Activity) {
+            if (currentActivity == activity) currentActivity = null
+        }
+        override fun onActivityDestroyed(activity: Activity) {
+            if (currentActivity == activity) currentActivity = null
+        }
+        override fun onActivityCreated(activity: Activity, b: Bundle?) {}
+        override fun onActivityStarted(activity: Activity) {}
+        override fun onActivityStopped(activity: Activity) {}
+        override fun onActivitySaveInstanceState(activity: Activity, b: Bundle) {}
+    })
+}
+
+/** Replace the logging stub from the integration page with this. */
+private fun onPackageDownloaded(oldVersion: String, newVersion: String) {
+    if (newVersion.isEmpty() || newVersion == oldVersion) return
+    pendingPrompt.set(newVersion)
+    // The download can land before MainActivity resumes; onActivityResumed drains it too.
+    currentActivity?.let { showPendingPrompt(it) }
+}
+
+private fun showPendingPrompt(activity: Activity) {
+    val staged = pendingPrompt.getAndSet(null) ?: return
+    activity.runOnUiThread { promptForReload(activity, staged) }
+}
+
+private fun promptForReload(activity: Activity, newVersion: String) {
+    AlertDialog.Builder(activity)
+        .setTitle("Update ready")
+        .setMessage("A new version ($newVersion) has downloaded. Reload now?")
+        .setPositiveButton("Reload now") { _, _ -> restartProcess(activity) }
+        .setNegativeButton("Later", null)
+        .setCancelable(false)
+        .show()
+}
+
+/**
+ * The staged bundle is installed during Airborne's init on the next process start, before React
+ * Native loads it — so restart the process rather than recreating the Activity.
+ */
+private fun restartProcess(activity: Activity) {
+    val intent = activity.packageManager
+        .getLaunchIntentForPackage(activity.packageName)!!
+        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+    activity.startActivity(intent)
+    activity.finish()
+    Runtime.getRuntime().exit(0)
+}
+```
+
+Wire the two callbacks in:
+
+```kotlin
+override fun onCreate() {
+    super.onCreate()
+    trackForegroundActivity()      // add this
+    startAirborne()
+    loadReactNative(this)
+}
+```
+
+And point `HyperOTAServices`' callback at the new handler:
+
+```kotlin
+onPackageDownloaded = { old, new -> onPackageDownloaded(old, new) },
+```
+
+## iOS — prompt and re-initialize
+
+iOS forbids programmatic process restart, so instead of killing the process you **re-create `AirborneServices`**. A fresh instance installs the staged package (moving it from temp into place) during its init, then fires `startApp(indexBundleURL:)` again with the new bundle URL — and the `reactStarted` guard in `bootReactNative` from [React Native (bare)](/docs/bare-integration/react-native) reloads JS onto it.
+
+Extend the `AppDelegate`: fill in `onPackageDownloaded` and add `applyStagedUpdate()`.
+
+```swift
+// Replace the logging stub from the integration page with this.
+func onPackageDownloaded(oldVersion: String, newVersion: String) {
+    guard !newVersion.isEmpty, newVersion != oldVersion else { return }
+    DispatchQueue.main.async { [weak self] in self?.promptForReload(version: newVersion) }
+}
+
+private func promptForReload(version: String) {
+    guard let root = window?.rootViewController else { return }
+    let alert = UIAlertController(
+        title: "Update ready",
+        message: "A new version (\(version)) has downloaded. Reload now?",
+        preferredStyle: .alert
+    )
+    alert.addAction(UIAlertAction(title: "Later", style: .cancel))
+    alert.addAction(UIAlertAction(title: "Reload now", style: .default) { [weak self] _ in
+        self?.applyStagedUpdate()
+    })
+    root.present(alert, animated: true)
+}
+
+/**
+ * Re-initialising AirborneServices installs the staged package during init and fires startApp()
+ * again with the new bundle URL. bootReactNative's reactStarted guard reloads RN onto it.
+ */
+private func applyStagedUpdate() {
+    airborne = AirborneServices(releaseConfigURL: RELEASE_CONFIG_URL, delegate: self)
+}
+```
+
+No other changes are needed: `bootReactNative` already handles the second `startApp` by swapping `airborneBundleURL` and calling `RCTTriggerReloadCommandListeners`.
+
+## Always prompt: set `boot_timeout` to `0`
+
+By default a package that downloads quickly is applied **inline** during boot, so `onPackageDownloaded` only fires on the slower launches where the download crosses the boot timeout. If you want the reload prompt to appear **every time** there is a new package — a consistent "an update is ready" experience rather than an occasional one — release with **`boot_timeout: 0`**.
+
+With a zero boot timeout the SDK never blocks boot waiting for downloads: React Native always boots immediately from the package already on disk, and any newer package always finishes *after* the (zero-length) timeout. It is therefore always **staged**, and `onPackageDownloaded` fires **every time** an update is available — so your prompt shows on every launch that has a pending update.
+
+`boot_timeout` is a property of the **release config**, set when you create the release from the dashboard — the SDK integration does not change. See [Create & target a release](/docs/guides/create-and-target-a-release) and the [Releases](/docs/dashboard/releases) reference.
+
+:::tip[Two supported strategies]
+- **Seamless when possible, prompt when slow** — use a normal `boot_timeout` (e.g. a few seconds). Fast updates apply silently on cold start; only late ones prompt.
+- **Always prompt** — set `boot_timeout: 0`. Cold start is never blocked, and every pending update surfaces a "Reload now" prompt via `onPackageDownloaded`.
+:::
+
+## See also
+
+- [Download & boot flow](/docs/concepts/download-and-boot-flow) — how the boot timeout decides applied vs. staged.
+- [Callbacks & events](/docs/react-native-sdk/reference/callbacks-and-events) — the wider event stream the SDK emits.

--- a/airborne_docs/docs/react-native-sdk/overview.md
+++ b/airborne_docs/docs/react-native-sdk/overview.md
@@ -33,6 +33,10 @@ The native boot wiring differs slightly depending on your project type:
 
 Both tracks use the same `airborne-react-native` package and the same release config and dimensions concepts described below.
 
+:::note[Advanced: bare integration]
+Teams that need low-level control over the OTA lifecycle — for example, reacting to the `onPackageDownloaded` callback to prompt a reload when an update lands after the boot timeout — can integrate the **native** Airborne SDKs directly, without this plugin. That is an advanced flow; for most apps the tracks above are simpler. See [Bare Integration (Advanced)](/docs/bare-integration/overview).
+:::
+
 ## Core concepts
 
 **Release Config** — the JSON Airborne fetches from your release URL. It describes which package and resources to boot, and is versioned so the SDK can detect and apply updates.

--- a/airborne_docs/sidebars.ts
+++ b/airborne_docs/sidebars.ts
@@ -72,6 +72,17 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: "category",
+          label: "Bare Integration (Advanced)",
+          link: { type: "doc", id: "bare-integration/overview" },
+          items: [
+            "bare-integration/overview",
+            "bare-integration/react-native",
+            "bare-integration/expo",
+            "bare-integration/reload-after-download",
+          ],
+        },
+        {
+          type: "category",
           label: "Airborne React Native CLI",
           link: { type: "doc", id: "react-native-cli/getting-started" },
           items: [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an advanced bare integration guide for React Native and Expo apps.
  * Documented Android and iOS setup, OTA boot behavior, bundle loading, and verification steps.
  * Added guidance for prompting reloads when updates download after the boot timeout.
  * Added navigation links and a new “Bare Integration (Advanced)” documentation section.
  * Added an overview callout directing advanced users to the new integration guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->