### PR TITLE
fix(ios): stop package install from wiping unchanged nested assets

### DIFF
--- a/airborne_sdk_iOS/hyper-ota/Airborne/AirborneSwift/AJPApplicationManager.swift
+++ b/airborne_sdk_iOS/hyper-ota/Airborne/AirborneSwift/AJPApplicationManager.swift
@@ -1183,7 +1183,7 @@ public typealias AJPReleaseConfigCompletionHandler = (AJPApplicationManifest?, E
         
         let currentSplits = currentManifest.allImportantSplits()
         let newSplits = newManifest.allImportantSplits()
-        let toDownload = utils.getResourcesFrom(newSplits, filtering: currentSplits, isFirstRunAfterInstallation: AJPApplicationManager.isFirstRunAfterInstallation)
+        let toDownload = utils.getResourcesFrom(newSplits, filtering: currentSplits, isFirstRunAfterInstallation: AJPApplicationManager.isFirstRunAfterInstallation, requiringPresenceInMain: true)
         
         self.tracker.trackInfo("important_package_download_started", value: NSMutableDictionary(dictionary: ["package_version": newManifest.version]))
         let packageStartTime = Date().timeIntervalSince1970 * 1000

--- a/airborne_sdk_iOS/hyper-ota/Airborne/AirborneSwift/AJPApplicationManagerUtils.swift
+++ b/airborne_sdk_iOS/hyper-ota/Airborne/AirborneSwift/AJPApplicationManagerUtils.swift
@@ -110,19 +110,46 @@ class AJPApplicationManagerUtils {
     
     // MARK: - Resources and Strings
     
-    func getResourcesFrom(_ newSplits: [AJPResource], filtering currentSplits: [AJPResource], isFirstRunAfterInstallation: Bool) -> [AJPResource] {
+    /// Filters `newSplits` down to the ones that actually need downloading.
+    ///
+    /// - Parameter requiringPresenceInMain: also queue a split whose file is missing from the
+    ///   package's `main` directory. Pass `true` for important splits, whose installation is
+    ///   gated on the file being present; leave it `false` for lazy splits, which are absent
+    ///   from disk until they are downloaded and track that through `isDownloaded`.
+    func getResourcesFrom(_ newSplits: [AJPResource], filtering currentSplits: [AJPResource], isFirstRunAfterInstallation: Bool, requiringPresenceInMain: Bool = false) -> [AJPResource] {
         if isFirstRunAfterInstallation {
             return newSplits
         }
-        
+
         var currentResourcesDict: [String: AJPResource] = [:]
         for currentResource in currentSplits {
             currentResourcesDict[currentResource.filePath] = currentResource
         }
-        
+
+        // Listed once up front rather than stat-ing per split. Comparing manifests cannot tell
+        // whether a file survived on disk, and a split that is missing from main/ will never be
+        // re-fetched by the diff alone — `isAppInstalled` then rejects the package on this and
+        // every later boot, pinning the app to its current version for good.
+        var filesInMain = Set<String>()
+        if requiringPresenceInMain {
+            filesInMain = Set(getAllFilesInDirectory(AJPApplicationConstants.JUSPAY_PACKAGE_DIR,
+                                                     subFolder: AJPApplicationConstants.JUSPAY_MAIN_DIR,
+                                                     includeSubfolders: true))
+        }
+
         return newSplits.filter { newResource in
             let currentResource = currentResourcesDict[newResource.filePath]
-            return shouldDownloadResource(newResource, existingResource: currentResource)
+            if shouldDownloadResource(newResource, existingResource: currentResource) {
+                return true
+            }
+
+            guard requiringPresenceInMain else { return false }
+
+            // Either name counts as present: the downloader writes `filePath` verbatim while
+            // `isAppInstalled` looks for the `.jsa` -> `.js` form, and honouring only one of them
+            // would re-download such a split on every single boot.
+            return !filesInMain.contains(newResource.filePath)
+                && !filesInMain.contains(jsFileName(for: newResource.filePath))
         }
     }
     
@@ -212,19 +239,28 @@ class AJPApplicationManagerUtils {
     func moveAllPackagesFromTempToMain() {
         let tempDirPath = fileUtil.fullPathInStorageForFilePath(AJPApplicationConstants.JUSPAY_TEMP_DIR, inFolder: AJPApplicationConstants.JUSPAY_PACKAGE_DIR)
 
-        guard let tempFiles = try? FileManager.default.contentsOfDirectory(atPath: tempDirPath) else {
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: tempDirPath, isDirectory: &isDirectory), isDirectory.boolValue else {
             let map = NSMutableDictionary()
             map["error"] = "Could not read temp directory"
             tracker.trackError("temp_directory_read_failed", value: map)
             return
         }
 
+        // Enumerated recursively so every entry handed to `movePackageFromTempToMain` is a file.
+        // Moving a top-level entry instead would hand it a *directory*, and that call deletes the
+        // destination before moving: `main/assets` would lose every file this update's delta did
+        // not re-download. This is the enumeration `handleTempPackageInstallation` already uses
+        // when installing a package staged after a boot timeout.
+        let tempFiles = getAllFilesInDirectory(AJPApplicationConstants.JUSPAY_PACKAGE_DIR,
+                                               subFolder: AJPApplicationConstants.JUSPAY_TEMP_DIR,
+                                               includeSubfolders: true)
+
+        var movedCount = 0
         for fileName in tempFiles {
             do {
                 try movePackageFromTempToMain(fileName)
-                let map = NSMutableDictionary()
-                map["file"] = fileName
-                tracker.trackInfo("file_moved_to_main", value: map)
+                movedCount += 1
             } catch {
                 let map = NSMutableDictionary()
                 map["file"] = fileName
@@ -232,6 +268,13 @@ class AJPApplicationManagerUtils {
                 tracker.trackError("file_move_failed", value: map)
             }
         }
+
+        // Reported once with a count rather than once per file: a package can carry hundreds of
+        // nested assets and this runs on the boot path. Failures are still logged individually.
+        let map = NSMutableDictionary()
+        map["count"] = NSNumber(value: movedCount)
+        map["total"] = NSNumber(value: tempFiles.count)
+        tracker.trackInfo("file_moved_to_main", value: map)
     }
 
     func moveResourceToMain(_ resource: AJPResource) {

--- a/airborne_sdk_iOS/hyper-ota/AirborneTestAppTests/AJPApplicationManagerUtilsTests.swift
+++ b/airborne_sdk_iOS/hyper-ota/AirborneTestAppTests/AJPApplicationManagerUtilsTests.swift
@@ -273,6 +273,57 @@ final class AJPApplicationManagerUtilsTests: XCTestCase {
         XCTAssertEqual(result.first?.filePath, "b.js")
     }
 
+    // MARK: - getResourcesFrom (requiringPresenceInMain)
+
+    func testGetResourcesFrom_requiringPresence_unchangedSplitMissingFromMain_downloads() {
+        let split = makeResource(url: "https://cdn.example.com/a.js", filePath: "a.js", checksum: "aaa")
+        let result = utils.getResourcesFrom([split], filtering: [split],
+                                            isFirstRunAfterInstallation: false,
+                                            requiringPresenceInMain: true)
+        XCTAssertEqual(result.count, 1,
+                       "A split identical in both manifests must still be re-downloaded when its file is gone from main")
+    }
+
+    func testGetResourcesFrom_requiringPresence_unchangedSplitPresentInMain_skips() throws {
+        try writeFile("a.js", subFolder: AJPApplicationConstants.JUSPAY_MAIN_DIR,
+                      inFolder: AJPApplicationConstants.JUSPAY_PACKAGE_DIR)
+        let split = makeResource(url: "https://cdn.example.com/a.js", filePath: "a.js", checksum: "aaa")
+        let result = utils.getResourcesFrom([split], filtering: [split],
+                                            isFirstRunAfterInstallation: false,
+                                            requiringPresenceInMain: true)
+        XCTAssertTrue(result.isEmpty, "An unchanged split already on disk must not be re-downloaded")
+    }
+
+    func testGetResourcesFrom_requiringPresence_nestedSplitPresentInMain_skips() throws {
+        let path = "assets/assets/images/chat-bg-light.png"
+        try writeFile(path, subFolder: AJPApplicationConstants.JUSPAY_MAIN_DIR,
+                      inFolder: AJPApplicationConstants.JUSPAY_PACKAGE_DIR)
+        let split = makeResource(url: "https://cdn.example.com/bg.png", filePath: path, checksum: "ccc")
+        let result = utils.getResourcesFrom([split], filtering: [split],
+                                            isFirstRunAfterInstallation: false,
+                                            requiringPresenceInMain: true)
+        XCTAssertTrue(result.isEmpty, "Presence must be detected for splits nested in subdirectories")
+    }
+
+    func testGetResourcesFrom_requiringPresence_jsaSplitStoredUnderRawName_skips() throws {
+        try writeFile("bundle.jsa", subFolder: AJPApplicationConstants.JUSPAY_MAIN_DIR,
+                      inFolder: AJPApplicationConstants.JUSPAY_PACKAGE_DIR)
+        let split = makeResource(url: "https://cdn.example.com/bundle.jsa", filePath: "bundle.jsa", checksum: "ddd")
+        let result = utils.getResourcesFrom([split], filtering: [split],
+                                            isFirstRunAfterInstallation: false,
+                                            requiringPresenceInMain: true)
+        XCTAssertTrue(result.isEmpty,
+                      "A .jsa split present under its raw name must count as installed, not re-download every boot")
+    }
+
+    func testGetResourcesFrom_withoutRequiringPresence_missingFromMain_stillSkips() {
+        let split = makeResource(url: "https://cdn.example.com/a.js", filePath: "a.js", checksum: "aaa")
+        let result = utils.getResourcesFrom([split], filtering: [split],
+                                            isFirstRunAfterInstallation: false)
+        XCTAssertTrue(result.isEmpty,
+                      "Lazy splits keep the manifest-only comparison: absence from main is their normal state")
+    }
+
     // MARK: - prepareTempDirectory / cleanupTempDirectory
 
     func testPrepareTempDirectory_createsTempDirectory() {
@@ -409,5 +460,93 @@ final class AJPApplicationManagerUtilsTests: XCTestCase {
 
         XCTAssertTrue(FileManager.default.fileExists(atPath: keep),
                       "deleteFile must only remove the targeted file")
+    }
+
+    // MARK: - moveAllPackagesFromTempToMain
+
+    /// Absolute path of `relativePath` inside the package's `main` directory.
+    private func mainPath(_ relativePath: String) -> String {
+        fileUtil.fullPathInStorageForFilePath(
+            "\(AJPApplicationConstants.JUSPAY_MAIN_DIR)/\(relativePath)",
+            inFolder: AJPApplicationConstants.JUSPAY_PACKAGE_DIR)
+    }
+
+    private func contents(ofMain relativePath: String) throws -> String {
+        try String(contentsOfFile: mainPath(relativePath), encoding: .utf8)
+    }
+
+    private func stageInTemp(_ relativePath: String, content: String) throws {
+        try writeFile(relativePath, subFolder: AJPApplicationConstants.JUSPAY_TEMP_DIR,
+                      inFolder: AJPApplicationConstants.JUSPAY_PACKAGE_DIR, content: content)
+    }
+
+    private func installInMain(_ relativePath: String, content: String) throws {
+        try writeFile(relativePath, subFolder: AJPApplicationConstants.JUSPAY_MAIN_DIR,
+                      inFolder: AJPApplicationConstants.JUSPAY_PACKAGE_DIR, content: content)
+    }
+
+    /// The regression this fix exists for: a delta update that re-downloads only part of a
+    /// directory must not take the rest of that directory down with it.
+    func testMoveAllPackages_partialUpdate_preservesUntouchedFilesInSameDirectory() throws {
+        try installInMain("assets/assets/images/chat-bg-light.png", content: "old-bg")
+        try installInMain("assets/assets/images/logo.png", content: "old-logo")
+
+        utils.prepareTempDirectory()
+        try stageInTemp("assets/assets/images/logo.png", content: "new-logo")
+
+        utils.moveAllPackagesFromTempToMain()
+
+        XCTAssertEqual(try contents(ofMain: "assets/assets/images/logo.png"), "new-logo",
+                       "The re-downloaded file must be installed")
+        XCTAssertEqual(try contents(ofMain: "assets/assets/images/chat-bg-light.png"), "old-bg",
+                       "A file the delta did not re-download must survive the install")
+    }
+
+    func testMoveAllPackages_movesNestedFilesPreservingStructure() throws {
+        utils.prepareTempDirectory()
+        try stageInTemp("main.jsbundle", content: "bundle")
+        try stageInTemp("assets/assets/images/chat-bg-light.png", content: "bg")
+
+        utils.moveAllPackagesFromTempToMain()
+
+        XCTAssertEqual(try contents(ofMain: "main.jsbundle"), "bundle")
+        XCTAssertEqual(try contents(ofMain: "assets/assets/images/chat-bg-light.png"), "bg")
+    }
+
+    func testMoveAllPackages_clearsMovedFilesFromTemp() throws {
+        utils.prepareTempDirectory()
+        try stageInTemp("assets/a.png", content: "a")
+
+        utils.moveAllPackagesFromTempToMain()
+
+        let leftovers = utils.getAllFilesInDirectory(AJPApplicationConstants.JUSPAY_PACKAGE_DIR,
+                                                     subFolder: AJPApplicationConstants.JUSPAY_TEMP_DIR,
+                                                     includeSubfolders: true)
+        XCTAssertTrue(leftovers.isEmpty, "Files must be moved out of temp, not copied")
+    }
+
+    func testMoveAllPackages_overwritesExistingDestinationFile() throws {
+        try installInMain("main.jsbundle", content: "old")
+        utils.prepareTempDirectory()
+        try stageInTemp("main.jsbundle", content: "new")
+
+        utils.moveAllPackagesFromTempToMain()
+
+        XCTAssertEqual(try contents(ofMain: "main.jsbundle"), "new")
+    }
+
+    func testMoveAllPackages_whenTempDirectoryAbsent_doesNotCrash() {
+        utils.cleanupTempDirectory()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tempDirPath))
+        XCTAssertNoThrow(utils.moveAllPackagesFromTempToMain())
+    }
+
+    func testMoveAllPackages_emptyTempDirectory_leavesMainUntouched() throws {
+        try installInMain("main.jsbundle", content: "installed")
+        utils.prepareTempDirectory()
+
+        utils.moveAllPackagesFromTempToMain()
+
+        XCTAssertEqual(try contents(ofMain: "main.jsbundle"), "installed")
     }
 }


### PR DESCRIPTION
## Symptom

An OTA update downloads successfully, then fails to install, and the app stays pinned to its old package version — permanently. From a production device:

```
init_with_local_config_versions   | package_version: 87
important_package_download_result | result: SUCCESS, time_taken: 1288 ms
file_moved_to_main                | file: main.jsbundle
file_moved_to_main                | file: assets
package_install_failed            | file_missing: assets/assets/images/chat-bg-light.png
package_update_result             | result: FAILED, reason: package copy failed
```

## Root cause

Two pieces that contradict each other:

- **Downloads are a delta.** `getResourcesFrom` only queues splits whose URL or checksum changed. Unchanged files are expected to already be on disk.
- **The install replaced whole top-level entries.** `moveAllPackagesFromTempToMain` listed temp with `contentsOfDirectory` (non-recursive), so for a package whose splits live in subdirectories it handed `movePackageFromTempToMain` a *directory* — and that call deletes the destination before moving. `main/assets` was replaced wholesale by whatever the delta happened to stage, deleting every unchanged file under it.

`isAppInstalled` then failed on the first missing file, so the manifest was never updated — but the new index bundle had already been moved into place. The app booted the **new** bundle against a **half-deleted** asset tree while the SDK believed it was still on the old version, and since the delta filter never consults the filesystem, the deleted files were never re-fetched. Every later launch repeated the same failure.

This is not a regression — the shape is unchanged since the original iOS import (`ff00b45`); the Swift migration (`92b7ed0`) was a faithful port. What changed recently is the app-version wipe added in `9ec317b`/`5a9b1b4`, which resets state on every app update and so hides the bug until the first *delta* OTA after it.

## Fix

1. **Enumerate temp recursively** so every entry moved is a file and the move merges instead of replacing. This is what `handleTempPackageInstallation` already does on the boot-timeout path, and what the Android SDK does via `TempWriter.copyToMain`. Intermediate directories are created by `fullPathInStorageForFilePath`, so nested paths need nothing further.
2. **Make the download filter self-healing** — an important split missing from `main/` is queued even when both manifests agree on it. Without this, devices already broken stay broken. Lazy splits keep the manifest-only comparison (absence from disk is their normal state), via a defaulted `requiringPresenceInMain` parameter passed only at the important-splits call site.

### Behavior change to be aware of

`file_moved_to_main` is now emitted **once with a `count`** rather than once per file — a package can carry hundreds of nested assets and this runs on the boot path. Any log query keyed on its `file` field needs updating. Move failures are still logged per file.

## Testing

**Unit** — 11 tests added to `AJPApplicationManagerUtilsTests` (6 for the move, 5 for the presence filter). The core regression test was verified as a genuine negative control: it fails against the old enumeration. Full suite otherwise green apart from three failures that pre-exist on a clean tree (two network-dependent suites plus `testGetCurrentApplicationManifest_configBootTimeout`).

**End-to-end** — driven through a real RN app on the simulator against a mock release-config server, two important splits nested at `assets/assets/images/`, `rev=a` original content and `rev=b` updated:

| # | Case | This PR | Before |
|---|---|---|---|
| S1 | none updated, in timeout | v2 · a, a | v2 · a, a |
| **S2** | **one updated, in timeout** | **v2 · a, b** | **v1 stuck · bg MISSING, logo b** |
| S3 | both updated, in timeout | v2 · b, b | v2 · b, b |
| S4 | none updated, after timeout | v2 · a, a | — |
| S5 | one updated, after timeout | v2 · a, b | v2 · a, b |
| S6 | both updated, after timeout | v2 · b, b | — |
| S7 | file missing + new release | v2 · a, a (healed) | v2 · bg still MISSING |
| S8 | file missing + same version | v1 · bg still MISSING | — |

The pre-fix run reproduced the production log line for line, including `file_moved_to_main | file: assets` and the same `file_missing` path. Two notes from the matrix:

- **S5/S3 pass even before this PR** — the after-timeout path already merged correctly, and a release where *every* file in the directory changes is harmless. Only partial updates break, which is why this stayed latent.
- **S7 before this PR was worse than "stuck"**: with nothing changed in the manifest, the `toDownload.isEmpty` early return skips the install gate entirely, so the version bumped to v2 with the file still missing — silent corruption, nothing logged.

## Not addressed

- **S8**: when a file is missing and the release config version is *unchanged*, `tryDownloadingUpdate` short-circuits before the filter runs, so nothing heals. Recovery still needs a new release or an app-version bump.
- A failed install still leaves the new `main.jsbundle` in place rather than staging the package atomically.
- `.zip` splits are saved but never extracted; `.jsa` splits are written under their raw name while the install gate looks for the `.js` form.

No docs impact: no public API, CLI, env-var, or dashboard surface, and these tracker events are not referenced in `airborne_docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package downloads by identifying important resources that are missing from the main installation.
  * Recognized equivalent `.js` and `.jsa` resource files when checking installed content.
  * Preserved nested folder structures and existing files during package installation.
  * Safely handled empty or unavailable temporary package directories.
  * Consolidated installation progress reporting while retaining details for failed file moves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->