### PR TITLE
feat(analytics): make CORS origins configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6236,6 +6236,10 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/airborne_analytics_server/.env.example
+++ b/airborne_analytics_server/.env.example
@@ -6,6 +6,13 @@ DEFAULT_TENANT_ID=airborne
 # Server Configuration
 SERVER_PORT=6400
 
+# Browser origins allowed to call the analytics endpoints, comma separated.
+# Unset (or "*") allows any origin, which is intended for deployments where a
+# CDN or gateway in front of this service enforces CORS itself. If you expose
+# this service directly, set an allow-list: without one, any site a user visits
+# can read these endpoints from their browser.
+# CORS_ALLOWED_ORIGINS=https://airborne.example.com,http://localhost:3000
+
 # Kafka Configuration
 KAFKA_BROKERS=localhost:9092
 KAFKA_TOPIC=ota-events

--- a/airborne_analytics_server/Cargo.toml
+++ b/airborne_analytics_server/Cargo.toml
@@ -31,3 +31,7 @@ tower-http = { version = "0.5", features = ["cors", "trace", "timeout"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
+
+[dev-dependencies]
+# `util` brings in ServiceExt::oneshot, used to drive the CORS layer in tests.
+tower = { version = "0.4", features = ["util"] }

--- a/airborne_analytics_server/src/common/config.rs
+++ b/airborne_analytics_server/src/common/config.rs
@@ -16,6 +16,52 @@ pub struct Config {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServerConfig {
     pub port: u16,
+    pub cors: CorsPolicy,
+}
+
+/// Which browser origins may call this service.
+///
+/// Deployments that terminate at a CDN or gateway usually let that edge own
+/// CORS, in which case `AllowAny` here is deliberate. Self-hosted deployments
+/// that expose the service directly need an allow-list, otherwise any site a
+/// user visits can read analytics for any tenant from their browser.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CorsPolicy {
+    AllowAny,
+    AllowList(Vec<String>),
+}
+
+impl CorsPolicy {
+    /// Parses `CORS_ALLOWED_ORIGINS`.
+    ///
+    /// Unset, empty, or `*` selects `AllowAny`, preserving the historical
+    /// behaviour so CDN-fronted deployments keep working untouched. Anything
+    /// else is a comma-separated allow-list.
+    pub fn from_env_value(raw: Option<&str>) -> Self {
+        let Some(value) = raw.map(str::trim).filter(|value| !value.is_empty()) else {
+            return CorsPolicy::AllowAny;
+        };
+
+        if value == "*" {
+            return CorsPolicy::AllowAny;
+        }
+
+        let origins: Vec<String> = value
+            .split(',')
+            .map(str::trim)
+            .filter(|origin| !origin.is_empty())
+            .map(str::to_string)
+            .collect();
+
+        // A value consisting only of separators expresses no origins at all.
+        // Treat it as unset rather than as "deny everything", so a stray comma
+        // cannot silently break a deployment; the startup warning still fires.
+        if origins.is_empty() {
+            return CorsPolicy::AllowAny;
+        }
+
+        CorsPolicy::AllowList(origins)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -46,6 +92,7 @@ impl Config {
                 port: env::var("SERVER_PORT").map_or(6400, |v| {
                     v.parse().expect("SERVER_PORT must be a valid number")
                 }),
+                cors: CorsPolicy::from_env_value(env::var("CORS_ALLOWED_ORIGINS").ok().as_deref()),
             },
             kafka: KafkaConfig {
                 brokers: env::var("KAFKA_BROKERS").unwrap_or_else(|_| "localhost:9092".to_string()),
@@ -73,5 +120,82 @@ impl Config {
         };
 
         Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Deployments that front this service with a CDN rely on the historical
+    /// permissive behaviour, so an absent variable must not start restricting.
+    #[test]
+    fn unset_or_blank_allows_any_origin() {
+        assert_eq!(CorsPolicy::from_env_value(None), CorsPolicy::AllowAny);
+        assert_eq!(CorsPolicy::from_env_value(Some("")), CorsPolicy::AllowAny);
+        assert_eq!(
+            CorsPolicy::from_env_value(Some("   ")),
+            CorsPolicy::AllowAny
+        );
+    }
+
+    #[test]
+    fn wildcard_allows_any_origin() {
+        assert_eq!(CorsPolicy::from_env_value(Some("*")), CorsPolicy::AllowAny);
+        assert_eq!(
+            CorsPolicy::from_env_value(Some("  *  ")),
+            CorsPolicy::AllowAny
+        );
+    }
+
+    #[test]
+    fn single_origin_is_allow_listed() {
+        assert_eq!(
+            CorsPolicy::from_env_value(Some("https://airborne.example.com")),
+            CorsPolicy::AllowList(vec!["https://airborne.example.com".to_string()])
+        );
+    }
+
+    #[test]
+    fn comma_separated_origins_are_split_and_trimmed() {
+        assert_eq!(
+            CorsPolicy::from_env_value(Some(
+                " https://a.example.com , https://b.example.com:8443 "
+            )),
+            CorsPolicy::AllowList(vec![
+                "https://a.example.com".to_string(),
+                "https://b.example.com:8443".to_string(),
+            ])
+        );
+    }
+
+    /// A value of only separators names no origins. Falling back to the
+    /// documented default beats inventing a deny-everything policy from what
+    /// is almost certainly a typo — the startup warning still surfaces it.
+    #[test]
+    fn separator_only_value_falls_back_to_any() {
+        assert_eq!(CorsPolicy::from_env_value(Some(",")), CorsPolicy::AllowAny);
+        assert_eq!(
+            CorsPolicy::from_env_value(Some(" , , ")),
+            CorsPolicy::AllowAny
+        );
+    }
+
+    /// An allow-list must never silently collapse into "any origin".
+    #[test]
+    fn allow_list_never_degrades_to_allow_any() {
+        for raw in [
+            "https://a.example.com",
+            "https://a.example.com,https://b.example.com",
+            "http://localhost:3000",
+        ] {
+            assert!(
+                matches!(
+                    CorsPolicy::from_env_value(Some(raw)),
+                    CorsPolicy::AllowList(_)
+                ),
+                "{raw:?} should produce an allow-list"
+            );
+        }
     }
 }

--- a/airborne_analytics_server/src/main.rs
+++ b/airborne_analytics_server/src/main.rs
@@ -8,24 +8,73 @@ use std::{net::SocketAddr, sync::Arc, time::Duration};
 use anyhow::Result;
 use axum::{
     error_handling::HandleErrorLayer,
+    http::{header, HeaderValue, Method},
     response::IntoResponse,
     routing::{get, post},
     Router,
 };
 use tower::ServiceBuilder;
-use tower_http::{cors::CorsLayer, timeout::TimeoutLayer, trace::TraceLayer};
-use tracing::{error, info};
+use tower_http::{
+    cors::{AllowOrigin, CorsLayer},
+    timeout::TimeoutLayer,
+    trace::TraceLayer,
+};
+use tracing::{error, info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 use crate::{
     common::{
-        config::Config,
+        config::{Config, CorsPolicy},
         models::{AppState, ErrorResponse, LoggingInfra},
     },
     core::kafka,
     core::{bootstrap_clickhouse, victoria},
     handlers::{analytics, events, health},
 };
+
+/// Builds the CORS layer from the configured policy.
+///
+/// `AllowAny` reproduces the previous `CorsLayer::permissive()` behaviour and
+/// is correct when a CDN or gateway in front of this service owns CORS. When
+/// nothing sits in front, an allow-list is what stops an arbitrary site from
+/// reading another tenant's analytics out of a visitor's browser.
+fn build_cors_layer(policy: &CorsPolicy) -> Result<CorsLayer> {
+    match policy {
+        CorsPolicy::AllowAny => {
+            warn!(
+                "CORS is allowing any origin. Set CORS_ALLOWED_ORIGINS to an \
+                 allow-list if this service is exposed without a CDN or gateway \
+                 that enforces CORS on its behalf."
+            );
+            Ok(CorsLayer::permissive())
+        }
+        CorsPolicy::AllowList(origins) => {
+            let parsed = origins
+                .iter()
+                .map(|origin| {
+                    HeaderValue::from_str(origin).map_err(|e| {
+                        anyhow::anyhow!(
+                            "Invalid origin {:?} in CORS_ALLOWED_ORIGINS: {}",
+                            origin,
+                            e
+                        )
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
+
+            info!(
+                "CORS restricted to {} origin(s): {:?}",
+                parsed.len(),
+                origins
+            );
+
+            Ok(CorsLayer::new()
+                .allow_origin(AllowOrigin::list(parsed))
+                .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
+                .allow_headers([header::CONTENT_TYPE]))
+        }
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -109,6 +158,10 @@ async fn main() -> Result<()> {
 
     let server_port = config.server.port;
 
+    // Built before the listener binds so a malformed allow-list fails startup
+    // loudly rather than silently degrading to a policy nobody chose.
+    let cors_layer = build_cors_layer(&config.server.cors)?;
+
     let safe_layer = ServiceBuilder::new()
         .layer(HandleErrorLayer::new(|err| async move {
             ErrorResponse::internal(err).into_response()
@@ -132,7 +185,7 @@ async fn main() -> Result<()> {
             "/analytics/performance",
             get(analytics::get_performance_metrics),
         )
-        .layer(CorsLayer::permissive())
+        .layer(cors_layer)
         .layer(TraceLayer::new_for_http())
         .layer(safe_layer)
         .with_state(app_state.clone());
@@ -168,4 +221,85 @@ async fn main() -> Result<()> {
     info!("OTA Analytics Server stopped");
 
     Ok(())
+}
+
+#[cfg(test)]
+mod cors_tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    const ALLOWED: &str = "https://airborne.example.com";
+    const OTHER: &str = "https://evil.example.com";
+
+    /// Drives a real request through the configured CORS layer and returns the
+    /// `access-control-allow-origin` the browser would receive, if any.
+    async fn allow_origin_header_for(policy: &CorsPolicy, request_origin: &str) -> Option<String> {
+        let app = Router::new()
+            .route("/analytics/adoption", get(|| async { "{}" }))
+            .layer(build_cors_layer(policy).expect("layer should build"));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/analytics/adoption")
+                    .header("origin", request_origin)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        response
+            .headers()
+            .get("access-control-allow-origin")
+            .map(|value| value.to_str().unwrap().to_string())
+    }
+
+    /// The security property: an origin outside the allow-list must not receive
+    /// permission to read the response, or any site a user visits can pull
+    /// another tenant's analytics out of their browser.
+    #[tokio::test]
+    async fn allow_list_rejects_unlisted_origin() {
+        let policy = CorsPolicy::AllowList(vec![ALLOWED.to_string()]);
+
+        assert_eq!(
+            allow_origin_header_for(&policy, ALLOWED).await.as_deref(),
+            Some(ALLOWED),
+            "the listed origin should be permitted"
+        );
+        assert_eq!(
+            allow_origin_header_for(&policy, OTHER).await,
+            None,
+            "an unlisted origin must not be granted access"
+        );
+    }
+
+    /// The documented default must keep behaving exactly as the previous
+    /// `CorsLayer::permissive()` did, so CDN-fronted deployments are unaffected.
+    #[tokio::test]
+    async fn allow_any_permits_arbitrary_origins() {
+        let policy = CorsPolicy::AllowAny;
+
+        assert_eq!(
+            allow_origin_header_for(&policy, OTHER).await.as_deref(),
+            Some("*"),
+            "AllowAny should keep permitting every origin"
+        );
+    }
+
+    /// A malformed origin must fail startup rather than degrade to some other
+    /// policy the operator did not choose.
+    #[test]
+    fn malformed_origin_fails_to_build() {
+        let policy = CorsPolicy::AllowList(vec!["ht\ntp://broken".to_string()]);
+
+        assert!(
+            build_cors_layer(&policy).is_err(),
+            "an unparseable origin must be rejected at startup"
+        );
+    }
 }

--- a/airborne_docs/docs/server/configuration.md
+++ b/airborne_docs/docs/server/configuration.md
@@ -271,6 +271,7 @@ The analytics server (`airborne_analytics_server`) is an **optional, separate** 
 | Variable | Required | Default / Example | Purpose |
 | --- | --- | --- | --- |
 | `SERVER_PORT` | No | `6400` | Port the analytics HTTP server binds on. |
+| `CORS_ALLOWED_ORIGINS` | No | _(unset — any origin)_ | Comma-separated list of browser origins allowed to call the analytics endpoints, for example `https://airborne.example.com,https://admin.example.com`. Unset (or `*`) allows **any** origin. See [Analytics CORS](#analytics-cors) below. |
 | `LOGGING_INFRASTRUCTURE` | No | `victoria-metrics` | Backend selector: `kafka-clickhouse` or `victoria-metrics`. Defaults to Victoria Metrics. |
 | `KAFKA_BROKERS` | No | `localhost:9092` | Kafka bootstrap brokers. |
 | `KAFKA_TOPIC` | No | `ota-events` | Kafka topic consumed for OTA events. |
@@ -287,4 +288,25 @@ The analytics server (`airborne_analytics_server`) is an **optional, separate** 
 
 :::caution
 The analytics `.env.example` also lists `DEFAULT_TENANT_ID`, and the stack-specific env files (`.env.victoria-metrics`, `.env.kafka-clickhouse`) use `KAFKA_BROKER_URL` and `VICTORIA_METRICS_URL`. These names are **not read** by `config.rs` in the current code — the parser reads `KAFKA_BROKERS` (not `KAFKA_BROKER_URL`) and has no Victoria-Metrics URL variable. Treat the table above (the variables `config.rs` actually parses) as authoritative, and the extra names as scaffolding for the Docker stacks.
+:::
+
+### Analytics CORS
+
+`CORS_ALLOWED_ORIGINS` controls which browser origins may call the analytics endpoints.
+
+| Value | Effect |
+| --- | --- |
+| unset, empty, or `*` | Any origin is allowed. |
+| `https://a.example.com,https://b.example.com` | Only the listed origins are allowed, for `GET`, `POST`, and `OPTIONS` with a `Content-Type` header. |
+
+Origins are compared exactly, so include the scheme and any non-default port (`http://localhost:3000`). A value the parser cannot read as an HTTP header fails startup rather than silently falling back to a different policy.
+
+:::caution[Set an allow-list if nothing in front enforces CORS]
+The default allows **any** origin, which is what you want when a CDN or gateway terminates in front of the service and owns CORS itself — the Airborne-hosted deployment does this at CloudFront.
+
+If you self-host and expose the analytics service directly, set `CORS_ALLOWED_ORIGINS`. Without it, any website a signed-in user visits can read your analytics endpoints from their browser. The service starts with a warning in its logs whenever it is running in allow-any mode, so check for that line after deploying.
+:::
+
+:::note[CORS is not authentication]
+CORS is a browser-enforced control. It does not stop a direct request from `curl` or a server, and the analytics endpoints do not currently authenticate callers or check that you are entitled to the `org_id` you ask for. Keep the service on a private network, or behind a gateway that authenticates, if the data is sensitive.
 :::


### PR DESCRIPTION
## Problem

The analytics router hard-coded `CorsLayer::permissive()`:

```rust
.layer(CorsLayer::permissive())
```

Every analytics endpoint accepted any origin, with no way to change it. That is fine for the hosted deployment, where CloudFront sits in front and owns CORS. It is not fine for self-hosted deployments that expose the service directly: any website a signed-in user visits can read the analytics endpoints from their browser, and `org_id` is just a query parameter.

Audit reference: **S10**.

## Change

New `CORS_ALLOWED_ORIGINS` environment variable:

| Value | Effect |
| --- | --- |
| unset / empty / `*` | Any origin — **unchanged** from today's behaviour, plus a startup warning naming the variable |
| `https://a.example.com,https://b.example.com` | Only those origins, for `GET`/`POST`/`OPTIONS` with `Content-Type` |

Design notes:

- **The default is deliberately unchanged.** CDN-fronted deployments must keep working after this upgrade, so allow-any stays the default rather than becoming a breaking change. The warning is what surfaces it to self-hosted operators.
- **Malformed origins fail startup** rather than falling back to some other policy. Silently degrading to permissive on a typo would be the worst outcome.
- **A separator-only value** (`","`) is treated as unset rather than as deny-everything, so a stray comma cannot silently break a deployment. The warning still fires.

## Testing

9 tests, all passing:

```
common::config::tests::unset_or_blank_allows_any_origin ... ok
common::config::tests::wildcard_allows_any_origin ... ok
common::config::tests::single_origin_is_allow_listed ... ok
common::config::tests::comma_separated_origins_are_split_and_trimmed ... ok
common::config::tests::separator_only_value_falls_back_to_any ... ok
common::config::tests::allow_list_never_degrades_to_allow_any ... ok
cors_tests::allow_list_rejects_unlisted_origin ... ok
cors_tests::allow_any_permits_arbitrary_origins ... ok
cors_tests::malformed_origin_fails_to_build ... ok
```

The `cors_tests` are behavioural, not just parsing — they drive a real request through the built layer with `ServiceExt::oneshot` and assert on the `access-control-allow-origin` header the browser would actually receive. `allow_list_rejects_unlisted_origin` is the one that matters: a listed origin gets the header back, an unlisted one gets nothing.

This needed `tower`'s `util` feature, added as a **dev-dependency** only.

`cargo fmt --check` and `cargo clippy --all-targets -- -Dwarnings` pass.

## Docs

- `airborne_docs/docs/server/configuration.md` — added the variable to the analytics env table (which is required to stay exhaustive) plus an **Analytics CORS** section covering the value grammar and exact-match semantics.
- Documented explicitly that **CORS is not authentication**: it does not stop `curl`, and these endpoints still do not authenticate callers or check entitlement to the requested `org_id`. I did not want this change to read as though it closes the tenant-isolation gap — that is a separate finding.
- `airborne_analytics_server/.env.example` — commented example.

`npm run build` in `airborne_docs` passes (exit 0). The `Multiple sidebars found for route /blog/welcome/` line is the pre-existing, documented `docusaurus-plugin-llms-txt` noise, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)