### PR TITLE
fix: check for bundled paths

### DIFF
--- a/airborne_sdk_iOS/hyper-ota/Airborne/AirborneSwift/AJPApplicationManager.swift
+++ b/airborne_sdk_iOS/hyper-ota/Airborne/AirborneSwift/AJPApplicationManager.swift
@@ -656,10 +656,21 @@ public typealias AJPReleaseConfigCompletionHandler = (AJPApplicationManifest?, E
             isAvailable = _downloadedSplits.contains(path)
         }
         
-        if !isAvailable { return nil }
-        
         let resolvedFileName = utils.jsFileName(for: path)
-        return getPathForPackageFile(resolvedFileName)
+        let packagePath = getPathForPackageFile(resolvedFileName)
+        
+        if isAvailable && FileManager.default.fileExists(atPath: packagePath) {
+            return packagePath
+        }
+        
+        let bundledFileName = (resolvedFileName as NSString).lastPathComponent
+            
+        if let bundledPath = fileUtil.filePathInBundleForFileName(bundledFileName),
+           FileManager.default.fileExists(atPath: bundledPath) {
+            return bundledPath
+        }
+        
+        return nil
     }
     
     @objc public func getDownloadedSplits() -> Set<String> {

--- a/airborne_server/src/build.rs
+++ b/airborne_server/src/build.rs
@@ -268,17 +268,12 @@ struct File {
     file_url: String,
 }
 
-fn sanitize_path(path: &str, replace_with_hyphen: bool) -> String {
+fn sanitize_path(path: &str) -> String {
     let mut result = path.to_string();
 
     // Remove leading slash if present
     if result.starts_with('/') {
         result.remove(0);
-    }
-
-    // Replace all remaining slashes with hyphens only for iOS zip files
-    if replace_with_hyphen {
-        result = result.replace('/', "-");
     }
 
     result
@@ -347,10 +342,7 @@ async fn create_and_upload_build(
             // Add file to zip with its file path as the name
             zip_builder
                 .start_file::<_, ()>(
-                    format!(
-                        "AirborneAssets/{}",
-                        sanitize_path(&file_entry.file_path, true)
-                    ),
+                    format!("AirborneAssets/{}", sanitize_path(&file_entry.file_path)),
                     FileOptions::default(),
                 )
                 .map_err(|e| {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asset file lookup for release configurations.
  * Correctly falls back to bundled assets when downloaded resources are unavailable.
  * Prevents invalid file paths from being returned when no matching asset exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->